### PR TITLE
Give radios and access groups, take duffelsbags

### DIFF
--- a/Resources/Prototypes/_CM14/Entities/Objects/Clothing/headsets.yml
+++ b/Resources/Prototypes/_CM14/Entities/Objects/Clothing/headsets.yml
@@ -627,4 +627,4 @@
   - type: ContainerFill
     containers:
       key_slots:
-      - CMEncryptionColony
+      - CMEncryptionKeyColony

--- a/Resources/Prototypes/_CM14/Entities/Objects/Clothing/headsets.yml
+++ b/Resources/Prototypes/_CM14/Entities/Objects/Clothing/headsets.yml
@@ -616,3 +616,15 @@
       - CMEncryptionKeyFoxtrot
       - CMEncryptionKeyMedical
       - CMEncryptionKeyCommon
+
+# Other
+- type: entity
+  parent: CMHeadset
+  id: CMHeadsetColony
+  name: colony headset
+  description: A standard headset used by colonists.
+  components:
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - CMEncryptionColony

--- a/Resources/Prototypes/_CM14/Entities/Objects/IdCards/cm_id_other.yml
+++ b/Resources/Prototypes/_CM14/Entities/Objects/IdCards/cm_id_other.yml
@@ -6,3 +6,10 @@
   - type: PresetIdCard
     job: Correspondent
 
+- type: entity
+  parent: CMIDCardLanyard
+  id: ColonistIDCard
+  name: colonist ID card
+  components:
+  - type: PresetIdCard
+    job: Survivor

--- a/Resources/Prototypes/_CM14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
@@ -15,8 +15,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-command
   canBeAntag: false
-  #accessGroups:
-  #- ASO
+  accessGroups:
+  - ASO
 
 - type: startingGear
   id: ASOGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
@@ -15,29 +15,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-command
   canBeAntag: false
-  access:
-  # Senior
-  # Database
-  # ASO
-  - Command
-  - Brig
-  - Armory
-  - Medical
-  - ChiefEngineer
-  - Engineering
-  - Maintenance
-  # Ordnance
-  - Quartermaster
-  - Cargo
-  # Prep
-  # Alpha
-  # Bravo
-  # Charlie
-  # Delta
-  # Pilot
-  # Dropship
-  - Kitchen
-  # Press
+  #accessGroups:
+  #- ASO
 
 - type: startingGear
   id: ASOGear
@@ -47,10 +26,8 @@
     back: ClothingBackpackCaptainFilled
     shoes: CMShoesCombatBootsBrown
     id: ASOIDCard
-    ears: ClothingHeadsetAltCommand
-  innerClothingSkirt: CMJumpsuitBO
+    ears: CMHeadsetLeader
   satchel: ClothingBackpackSatchelCMOFilled
-  duffelbag: ClothingBackpackDuffelCaptainFilled
 
 - type: entity
   id: CMSpawnPointASO

--- a/Resources/Prototypes/_CM14/Roles/Jobs/AuxiliarySupport/dropship_crew_chief.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/AuxiliarySupport/dropship_crew_chief.yml
@@ -10,8 +10,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-command
   canBeAntag: true
-  #accessGroups:
-  #- DropshipCrewChief
+  accessGroups:
+  - DropshipCrewChief
 
 - type: startingGear
   id: DCCGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/AuxiliarySupport/dropship_crew_chief.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/AuxiliarySupport/dropship_crew_chief.yml
@@ -9,11 +9,9 @@
   requireAdminNotify: false
   joinNotifyCrew: true
   supervisors: job-supervisors-command
-  canBeAntag: false
-  access:
-  - Command
-  # Dropship
-  # Pilot
+  canBeAntag: true
+  #accessGroups:
+  #- DropshipCrewChief
 
 - type: startingGear
   id: DCCGear
@@ -25,10 +23,8 @@
     shoes: CMShoesCombatBoots
     head: CMHeadCap
     id: DCCIDCard
-    ears: ClothingHeadsetSecurity
-  innerClothingSkirt: CMJumpsuitDCC
+    ears: CMHeadsetPilot
   satchel: ClothingBackpackSatchelFilled
-  duffelbag: ClothingBackpackDuffelFilled
 
 - type: entity
   id: CMSpawnPointDCC

--- a/Resources/Prototypes/_CM14/Roles/Jobs/AuxiliarySupport/intel_officer.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/AuxiliarySupport/intel_officer.yml
@@ -14,8 +14,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-command
   canBeAntag: false
-  #accessGroups:
-  #- IntelOfficer
+  accessGroups:
+  - IntelOfficer
 
 - type: startingGear
   id: IntelOfficerGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/AuxiliarySupport/intel_officer.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/AuxiliarySupport/intel_officer.yml
@@ -14,14 +14,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-command
   canBeAntag: false
-  access:
-  - Command
-  # Dropship
-  # Prep
-  # Alpha
-  # Bravo
-  # Charlie
-  # Delta
+  #accessGroups:
+  #- IntelOfficer
 
 - type: startingGear
   id: IntelOfficerGear
@@ -33,10 +27,8 @@
     shoes: CMShoesCombatBoots
     head: CMArmorHelmetM12
     id: IntelOfficerIDCard
-    ears: ClothingHeadsetSecurity
-  innerClothingSkirt: CMJumpsuitIO
+    ears: CMHeadsetIntel
   satchel: ClothingBackpackSatchelFilled
-  duffelbag: ClothingBackpackDuffelFilled
 
 - type: entity
   id: CMSpawnPointIntelOfficer

--- a/Resources/Prototypes/_CM14/Roles/Jobs/AuxiliarySupport/pilot_officer.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/AuxiliarySupport/pilot_officer.yml
@@ -14,8 +14,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-command
   canBeAntag: false
-  #accessGroups:
-  #- PilotOfficer
+  accessGroups:
+  - PilotOfficer
 
 - type: startingGear
   id: PilotOfficerGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/AuxiliarySupport/pilot_officer.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/AuxiliarySupport/pilot_officer.yml
@@ -14,10 +14,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-command
   canBeAntag: false
-  access:
-  - Command
-  # Dropship
-  # Pilot
+  #accessGroups:
+  #- PilotOfficer
 
 - type: startingGear
   id: PilotOfficerGear
@@ -29,10 +27,8 @@
     shoes: CMShoesCombatBoots
     head: CMArmorHelmetM30
     id: PilotOfficerIDCard
-    ears: ClothingHeadsetSecurity
-  innerClothingSkirt: CMJumpsuitPilot
+    ears: CMHeadsetPilot
   satchel: ClothingBackpackSatchelFilled
-  duffelbag: ClothingBackpackDuffelFilled
 
 - type: entity
   id: CMSpawnPointPilot

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Civilians/correspondent.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Civilians/correspondent.yml
@@ -11,7 +11,7 @@
   supervisors: job-supervisors-command
   canBeAntag: true
   accessGroups:
-  - Correspondent
+  - CMCorrespondent
 
 - type: startingGear
   id: CorrespondentGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Civilians/correspondent.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Civilians/correspondent.yml
@@ -10,8 +10,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-command
   canBeAntag: true
-  #accessGroups:
-  #- Correspondent
+  accessGroups:
+  - Correspondent
 
 - type: startingGear
   id: CorrespondentGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Civilians/correspondent.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Civilians/correspondent.yml
@@ -10,10 +10,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-command
   canBeAntag: true
-  access:
-  - Command
-  # Press
-  # Prep
+  #accessGroups:
+  #- Correspondent
 
 - type: startingGear
   id: CorrespondentGear
@@ -23,10 +21,8 @@
     back: ClothingBackpackFilled
     shoes: CMShoesCombatBootsBrown
     id: CorrespondentIDCard
-    ears: ClothingHeadsetGrey
-  innerClothingSkirt: CMJumpsuitCorrespondent
+    ears: CMHeadsetReporter
   satchel: ClothingBackpackSatchelFilled
-  duffelbag: ClothingBackpackDuffelFilled
 
 - type: entity
   id: CMSpawnPointCorrespondent

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Civilians/survivor.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Civilians/survivor.yml
@@ -21,7 +21,7 @@
   supervisors: job-supervisors-nobody
   canBeAntag: false
   accessGroups:
-  - Colony
+  - Colony #for playtest 1-2 only
 
 - type: startingGear
   id: SurvivorGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Civilians/survivor.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Civilians/survivor.yml
@@ -21,7 +21,7 @@
   supervisors: job-supervisors-nobody
   canBeAntag: false
   accessGroups:
-  - Colony #for playtest 1-2 only
+  - Colonist
 
 - type: startingGear
   id: SurvivorGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Civilians/survivor.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Civilians/survivor.yml
@@ -20,8 +20,8 @@
   joinNotifyCrew: false
   supervisors: job-supervisors-nobody
   canBeAntag: false
-  #accessGroups:
-  #- Colony
+  accessGroups:
+  - Colony
 
 - type: startingGear
   id: SurvivorGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Civilians/survivor.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Civilians/survivor.yml
@@ -20,6 +20,8 @@
   joinNotifyCrew: false
   supervisors: job-supervisors-nobody
   canBeAntag: false
+  #accessGroups:
+  #- Colony
 
 - type: startingGear
   id: SurvivorGear
@@ -27,10 +29,9 @@
     jumpsuit: CMJumpsuitColonist
     back: ClothingBackpackFilled
     shoes: CMShoesCombatBootsBrown
-    ears: ClothingHeadsetGrey
-  innerClothingSkirt: CMJumpsuitColonist
+    id: ColonistIDCard
+    ears: CMHeadsetColony
   satchel: ClothingBackpackSatchelFilled
-  duffelbag: ClothingBackpackDuffelFilled
 
 - type: entity
   id: CMSpawnPointSurvivor

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Command/commanding_officer.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Command/commanding_officer.yml
@@ -27,8 +27,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-highcommand
   canBeAntag: false
-  accessGroups:
-  - AllAccess
+  #accessGroups:
+  #- ShipMasterAccess
 
 - type: startingGear
   id: CommandingOfficerGear
@@ -39,10 +39,8 @@
     head: CMHeadBeretCO
     outerClothing: CMCoatOfficer
     id: CommandingOfficerIDCard
-    ears: ClothingHeadsetAltCommand
-  innerClothingSkirt: CMJumpsuitCO
+    ears: CMHeadsetSeniorCommand
   satchel: ClothingBackpackSatchelCaptainFilled
-  duffelbag: ClothingBackpackDuffelCaptainFilled
 
 - type: entity
   id: SpawnPointCommandingOfficer

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Command/commanding_officer.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Command/commanding_officer.yml
@@ -27,8 +27,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-highcommand
   canBeAntag: false
-  #accessGroups:
-  #- ShipMasterAccess
+  accessGroups:
+  - ShipMasterAccess
 
 - type: startingGear
   id: CommandingOfficerGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Command/executive_officer.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Command/executive_officer.yml
@@ -18,8 +18,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-command
   canBeAntag: false
-  #accessGroups:
-  #- MarineMain
+  accessGroups:
+  - MarineMain
 
 - type: startingGear
   id: ExecutiveOfficerGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Command/executive_officer.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Command/executive_officer.yml
@@ -18,8 +18,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-command
   canBeAntag: false
-  accessGroups:
-  - AllAccess
+  #accessGroups:
+  #- MarineMain
 
 - type: startingGear
   id: ExecutiveOfficerGear
@@ -30,10 +30,8 @@
     head: CMHeadCap
     outerClothing: CMCoatOfficer
     id: ExecutiveOfficerIDCard
-    ears: ClothingHeadsetAltCommand
-  innerClothingSkirt: CMJumpsuitBO
+    ears: CMHeadsetLeader
   satchel: ClothingBackpackSatchelCaptainFilled
-  duffelbag: ClothingBackpackDuffelCaptainFilled
 
 - type: entity
   id: SpawnPointExecutiveOfficer

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Command/senior_enlisted_advisor.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Command/senior_enlisted_advisor.yml
@@ -27,7 +27,7 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-command
   canBeAntag: false
-  accessGroups:
+  #accessGroups:
   #- MarineMain
 
 - type: startingGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Command/senior_enlisted_advisor.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Command/senior_enlisted_advisor.yml
@@ -27,8 +27,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-command
   canBeAntag: false
-  #accessGroups:
-  #- MarineMain
+  accessGroups:
+  - MarineMain
 
 - type: startingGear
   id: SeniorEnlistedAdvisorGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Command/senior_enlisted_advisor.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Command/senior_enlisted_advisor.yml
@@ -28,7 +28,7 @@
   supervisors: job-supervisors-command
   canBeAntag: false
   accessGroups:
-  - AllAccess #todo cm14
+  #- MarineMain
 
 - type: startingGear
   id: SeniorEnlistedAdvisorGear
@@ -38,10 +38,8 @@
     shoes: CMShoesCombatBootsBrown
     head: CMHeadCapDrill
     id: SeniorEnlistedAdvisorIDCard
-    ears: ClothingHeadsetAltCommand
-  innerClothingSkirt: CMJumpsuitBO
+    ears: CMHeadsetLeader
   satchel: ClothingBackpackSatchelCaptainFilled
-  duffelbag: ClothingBackpackDuffelCaptainFilled
 
 - type: entity
   id: SpawnPointSeniorEnlistedAdvisor

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Command/staff_officer.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Command/staff_officer.yml
@@ -17,8 +17,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-command
   canBeAntag: false
-  #accessGroups:
-  #- MarineMain
+  accessGroups:
+  - MarineMain
 
 - type: startingGear
   id: StaffOfficerGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Command/staff_officer.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Command/staff_officer.yml
@@ -17,11 +17,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-command
   canBeAntag: false
-  access:
-  - Command
-  # dropship
-  # database
-  - Medical
+  #accessGroups:
+  #- MarineMain
 
 - type: startingGear
   id: StaffOfficerGear
@@ -31,10 +28,8 @@
     shoes: CMShoesCombatBoots
     head: CMHeadCap
     id: StaffOfficerIDCard
-    ears: ClothingHeadsetAltCommand
-  innerClothingSkirt: CMJumpsuitBO
+    ears: CMHeadsetLeader
   satchel: ClothingBackpackSatchelCaptainFilled
-  duffelbag: ClothingBackpackDuffelCaptainFilled
 
 - type: entity
   id: SpawnPointStaffOfficer

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Engineering/chief_engineer.yml
@@ -18,16 +18,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-command
   canBeAntag: false
-  access:
-  - ChiefEngineer
-  - Engineering
-  - Command
-  # civ engi
-  # Database
-  - Maintenance
-  # OrdiTech
-  # Synth
-  # AI
+  #accessGroups:
+  #- CMCE
 
 - type: startingGear
   id: CMChiefEngineerGear
@@ -37,11 +29,9 @@
     shoes: CMShoesCombatBootsBrown
     gloves: CMHandsInsulated
     id: CMChiefEngineerIDCard
-    ears: ClothingHeadsetCE
+    ears: CMHeadsetCE
     belt: ClothingBeltUtilityEngineering
-  innerClothingSkirt: CMJumpsuitChiefEngineer
   satchel: ClothingBackpackSatchelChiefEngineerFilled
-  duffelbag: ClothingBackpackDuffelChiefEngineerFilled
 
 - type: entity
   id: CMSpawnPointChiefEngineer

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Engineering/chief_engineer.yml
@@ -18,8 +18,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-command
   canBeAntag: false
-  #accessGroups:
-  #- CMCE
+  accessGroups:
+  - CMCE
 
 - type: startingGear
   id: CMChiefEngineerGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Engineering/maint_tech.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Engineering/maint_tech.yml
@@ -14,10 +14,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-cm-chief-engineer
   canBeAntag: true
-  access:
-  - Engineering
-  # civ engi
-  - Maintenance
+  #accessGroups:
+  #- MaintTech
 
 - type: startingGear
   id: MaintTechGear
@@ -27,11 +25,9 @@
     shoes: CMShoesCombatBootsBrown
     gloves: CMHandsInsulated
     id: MaintTechIDCard
-    ears: ClothingHeadsetEngineering
+    ears: CMHeadsetEngineer
     belt: ClothingBeltUtilityEngineering
-  innerClothingSkirt: CMJumpsuitMaintTech
   satchel: ClothingBackpackSatchelEngineeringFilled
-  duffelbag: ClothingBackpackDuffelEngineeringFilled
 
 - type: entity
   id: SpawnPointMaintTech

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Engineering/maint_tech.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Engineering/maint_tech.yml
@@ -14,8 +14,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-cm-chief-engineer
   canBeAntag: true
-  #accessGroups:
-  #- MaintTech
+  accessGroups:
+  - MaintTech
 
 - type: startingGear
   id: MaintTechGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Engineering/ordnance_tech.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Engineering/ordnance_tech.yml
@@ -14,11 +14,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-cm-chief-engineer
   canBeAntag: true
-  access:
-  - Engineering
-  # civ engi
-  - Maintenance
-  # OrdiTech
+  #accessGroups:
+  #- OT
 
 - type: startingGear
   id: OrdnanceTechGear
@@ -28,11 +25,9 @@
     shoes: CMShoesCombatBootsBrown
     gloves: CMHandsInsulated
     id: OrdnanceTechIDCard
-    ears: ClothingHeadsetEngineering
+    ears: CMHeadsetEngineer
     belt: ClothingBeltUtilityEngineering
-  innerClothingSkirt: CMJumpsuitOrdnanceTech
   satchel: ClothingBackpackSatchelEngineeringFilled
-  duffelbag: ClothingBackpackDuffelEngineeringFilled
 
 - type: entity
   id: SpawnPointOrdnanceTech

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Engineering/ordnance_tech.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Engineering/ordnance_tech.yml
@@ -14,8 +14,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-cm-chief-engineer
   canBeAntag: true
-  #accessGroups:
-  #- OT
+  accessGroups:
+  - OT
 
 - type: startingGear
   id: OrdnanceTechGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/combat_tech.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/combat_tech.yml
@@ -12,8 +12,8 @@
   icon: "JobIconCombatTech"
   supervisors: job-supervisors-squad-leader
   canBeAntag: false
-  #accessGroups:
-  # -
+  accessGroups:
+  -
 
 - type: startingGear
   id: CombatTechGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/combat_tech.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/combat_tech.yml
@@ -13,7 +13,7 @@
   supervisors: job-supervisors-squad-leader
   canBeAntag: false
   accessGroups:
-  -
+  - CombatTech
 
 - type: startingGear
   id: CombatTechGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/combat_tech.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/combat_tech.yml
@@ -12,10 +12,8 @@
   icon: "JobIconCombatTech"
   supervisors: job-supervisors-squad-leader
   canBeAntag: false
-  access:
-  # Prep
-  # Engi Prep
-  - Engineering
+  #accessGroups:
+  # -
 
 - type: startingGear
   id: CombatTechGear
@@ -28,11 +26,9 @@
     outerClothing: ArmorMarineM3
     gloves: CMHandsInsulated
     id: DogtagCombatTech
-    ears: ClothingHeadsetSecurity
+    ears: CMHeadsetAlphaEngineer
     belt: ClothingBeltUtilityEngineering
-  innerClothingSkirt: CMJumpsuitMarineEngineer
   satchel: ClothingBackpackSatchelSecurityFilled
-  duffelbag: ClothingBackpackDuffelSecurityFilled
 
 - type: entity
   id: SpawnPointCombatTech

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/fireteam_leader.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/fireteam_leader.yml
@@ -12,8 +12,8 @@
   icon: "JobIconFireteamLeader"
   supervisors: job-supervisors-squad-leader
   canBeAntag: false
-  #accessGroups:
-  #-
+  accessGroups:
+  -
 
 - type: startingGear
   id: FireteamLeaderGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/fireteam_leader.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/fireteam_leader.yml
@@ -12,9 +12,8 @@
   icon: "JobIconFireteamLeader"
   supervisors: job-supervisors-squad-leader
   canBeAntag: false
-  #access:
-  # Prep
-  # Team Leader Prep
+  #accessGroups:
+  #-
 
 - type: startingGear
   id: FireteamLeaderGear
@@ -26,10 +25,8 @@
     outerClothing: CMArmorM4
     gloves: CMHandsBlack
     id: DogtagFireteamLeader
-    ears: ClothingHeadsetSecurity
-  innerClothingSkirt: CMJumpsuitMarineRTO
+    ears: CMHeadsetAlphaTeamLeader
   satchel: ClothingBackpackSatchelSecurityFilled
-  duffelbag: ClothingBackpackDuffelSecurityFilled
 
 - type: entity
   id: SpawnPointFireteamLeader

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/fireteam_leader.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/fireteam_leader.yml
@@ -13,7 +13,7 @@
   supervisors: job-supervisors-squad-leader
   canBeAntag: false
   accessGroups:
-  -
+  - FTL
 
 - type: startingGear
   id: FireteamLeaderGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/hospital_corpsman.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/hospital_corpsman.yml
@@ -16,7 +16,7 @@
   supervisors: job-supervisors-squad-leader
   canBeAntag: false
   accessGroups:
-  -
+  - HospitalCorpsman
 
 # TODO cm14 Remove this later
 - type: entity

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/hospital_corpsman.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/hospital_corpsman.yml
@@ -15,10 +15,8 @@
   icon: "JobIconHospitalCorpsman"
   supervisors: job-supervisors-squad-leader
   canBeAntag: false
-  access:
-  - Medical
-  # Prep
-  # Medical Prep
+  #accessGroups:
+  #-
 
 # TODO cm14 Remove this later
 - type: entity
@@ -42,11 +40,9 @@
     head: CMArmorHelmetM10Medic
     outerClothing: ArmorMarineM3
     id: DogtagHospitalCorpsman
-    ears: ClothingHeadsetBrigmedic
+    ears: CMHeadsetAlphaMedic
     belt: ClothingBeltMedicalFilled
-  innerClothingSkirt: CMJumpsuitMarineMedic
   satchel: ClothingBackpackSatchelBrigmedicFilled
-  duffelbag: ClothingBackpackDuffelBrigmedicFilled
 
 - type: entity
   name: survival box

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/hospital_corpsman.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/hospital_corpsman.yml
@@ -15,8 +15,8 @@
   icon: "JobIconHospitalCorpsman"
   supervisors: job-supervisors-squad-leader
   canBeAntag: false
-  #accessGroups:
-  #-
+  accessGroups:
+  -
 
 # TODO cm14 Remove this later
 - type: entity

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/hospital_corpsman.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/hospital_corpsman.yml
@@ -41,7 +41,7 @@
     outerClothing: ArmorMarineM3
     id: DogtagHospitalCorpsman
     ears: CMHeadsetAlphaMedic
-    belt: ClothingBeltMedicalFilled
+    belt: ClothingBeltMedicalFilled # todo cm14 replace with cm medical belt thingy
   satchel: ClothingBackpackSatchelBrigmedicFilled
 
 - type: entity

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/rifleman.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/rifleman.yml
@@ -9,7 +9,7 @@
   supervisors: job-supervisors-squad-leader
   canBeAntag: false
   accessGroups:
-  -
+  - Rifleman
 
 - type: startingGear
   id: RiflemanGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/rifleman.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/rifleman.yml
@@ -8,8 +8,8 @@
   icon: "JobIconRifleman"
   supervisors: job-supervisors-squad-leader
   canBeAntag: false
-  #accessGroups:
-  #-
+  accessGroups:
+  -
 
 - type: startingGear
   id: RiflemanGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/rifleman.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/rifleman.yml
@@ -8,8 +8,8 @@
   icon: "JobIconRifleman"
   supervisors: job-supervisors-squad-leader
   canBeAntag: false
-  #access:
-  #Prep
+  #accessGroups:
+  #-
 
 - type: startingGear
   id: RiflemanGear
@@ -21,10 +21,8 @@
     outerClothing: ArmorMarineM3
     gloves: CMHandsBlack
     id: DogtagRifleman
-    ears: ClothingHeadsetSecurity
-  innerClothingSkirt: JumpsuitMarine
+    ears: CMHeadsetAlpha
   satchel: ClothingBackpackSatchelSecurityFilled
-  duffelbag: ClothingBackpackDuffelSecurityFilled
 
 - type: entity
   id: SpawnPointRifleman

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/smartgunner.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/smartgunner.yml
@@ -12,8 +12,8 @@
   icon: "JobIconSmartgunner"
   supervisors: job-supervisors-squad-leader
   canBeAntag: false
-  #accessGroups:
-  #-
+  accessGroups:
+  -
 
 - type: startingGear
   id: SmartgunnerGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/smartgunner.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/smartgunner.yml
@@ -12,9 +12,8 @@
   icon: "JobIconSmartgunner"
   supervisors: job-supervisors-squad-leader
   canBeAntag: false
-  #access:
-  # Prep
-  # Smart Prep
+  #accessGroups:
+  #-
 
 - type: startingGear
   id: SmartgunnerGear
@@ -26,10 +25,8 @@
     outerClothing: ArmorMarineM3
     gloves: CMHandsBlack
     id: DogtagSmartgunner
-    ears: ClothingHeadsetSecurity
-  innerClothingSkirt: JumpsuitMarine
+    ears: CMHeadsetAlpha
   satchel: ClothingBackpackSatchelSecurityFilled
-  duffelbag: ClothingBackpackDuffelSecurityFilled
 
 - type: entity
   id: SpawnPointSmartGunner

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/smartgunner.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/smartgunner.yml
@@ -13,7 +13,7 @@
   supervisors: job-supervisors-squad-leader
   canBeAntag: false
   accessGroups:
-  -
+  - Smartgunner
 
 - type: startingGear
   id: SmartgunnerGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/squad_leader.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/squad_leader.yml
@@ -16,7 +16,7 @@
   supervisors: job-supervisors-command
   canBeAntag: false
   accessGroups:
-  -
+  - SquadLeader
 
 - type: startingGear
   id: SquadLeaderGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/squad_leader.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/squad_leader.yml
@@ -15,10 +15,8 @@
   icon: "JobIconSquadLeader"
   supervisors: job-supervisors-command
   canBeAntag: false
-  #access:
-  # Prep
-  # Leader
-  # Dropship
+  #accessGroups:
+  #-
 
 - type: startingGear
   id: SquadLeaderGear
@@ -30,10 +28,8 @@
     outerClothing: ArmorMarineM3
     gloves: CMHandsBlack
     id: DogtagSquadLeader
-    ears: ClothingHeadsetSecurity
-  innerClothingSkirt: CMJumpsuitMarineRTO
+    ears: CMHeadsetAlphaLeader
   satchel: ClothingBackpackSatchelSecurityFilled
-  duffelbag: ClothingBackpackDuffelSecurityFilled
 
 - type: entity
   id: SpawnPointSquadLeader

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/squad_leader.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/squad_leader.yml
@@ -15,8 +15,8 @@
   icon: "JobIconSquadLeader"
   supervisors: job-supervisors-command
   canBeAntag: false
-  #accessGroups:
-  #-
+  accessGroups:
+  -
 
 - type: startingGear
   id: SquadLeaderGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/weapons_specialist.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/weapons_specialist.yml
@@ -13,7 +13,7 @@
   supervisors: job-supervisors-squad-leader
   canBeAntag: false
   accessGroups:
-  -
+  - WeaponSpec
 
 - type: startingGear
   id: WeaponsSpecialistGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/weapons_specialist.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/weapons_specialist.yml
@@ -12,9 +12,8 @@
   icon: "JobIconWeaponsSpecialist"
   supervisors: job-supervisors-squad-leader
   canBeAntag: false
-  #access:
+  #accessGroups:
   # Prep
-  # Spec Prep
 
 - type: startingGear
   id: WeaponsSpecialistGear
@@ -26,10 +25,8 @@
     outerClothing: ArmorMarineM3
     gloves: CMHandsBlack
     id: DogtagWeaponsSpecialist
-    ears: ClothingHeadsetSecurity
-  innerClothingSkirt: JumpsuitMarine
+    ears: CMHeadsetAlpha
   satchel: ClothingBackpackSatchelSecurityFilled
-  duffelbag: ClothingBackpackDuffelSecurityFilled
 
 - type: entity
   id: SpawnPointWeaponsSpecialist

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/weapons_specialist.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/weapons_specialist.yml
@@ -12,8 +12,8 @@
   icon: "JobIconWeaponsSpecialist"
   supervisors: job-supervisors-squad-leader
   canBeAntag: false
-  #accessGroups:
-  # Prep
+  accessGroups:
+  -
 
 - type: startingGear
   id: WeaponsSpecialistGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -15,15 +15,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-command
   canBeAntag: false
-  access:
-  - ChiefMedicalOfficer
-  # Database
-  - Medical
-  # Research
-  # Senior
-  - Command
-  - Chemistry
-  # Morgue
+  #accessGroups:
+  #- CMCMO
 
 - type: startingGear
   id: MarineCMOGear
@@ -35,10 +28,8 @@
     shoes: CMShoesCombatBoots
     head: CMHeadCapCMO
     id: MarineCMOIDCard
-    ears: ClothingHeadsetCMO
-  innerClothingSkirt: CMJumpsuitCMO
+    ears: CMHeadsetCMO
   satchel: ClothingBackpackSatchelCMOFilled
-  duffelbag: ClothingBackpackDuffelCMOFilled
 
 - type: entity
   id: CMSpawnPointCMO

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -15,8 +15,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-command
   canBeAntag: false
-  #accessGroups:
-  #- CMCMO
+  accessGroups:
+  - CMCMO
 
 - type: startingGear
   id: MarineCMOGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Medical/doctor.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Medical/doctor.yml
@@ -14,8 +14,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-cm-cmo
   canBeAntag: true
-  #accessGroups:
-  #- CMMedical
+  accessGroups:
+  - CMMedical
 
 - type: startingGear
   id: MarineDoctorGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Medical/doctor.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Medical/doctor.yml
@@ -14,10 +14,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-cm-cmo
   canBeAntag: true
-  access:
-  - Medical
-  - Chemistry
-  # Morgue
+  #accessGroups:
+  #- CMMedical
 
 - type: startingGear
   id: MarineDoctorGear
@@ -29,10 +27,8 @@
     shoes: CMShoesCombatBoots
     head: CMHeadCapSurgBlue
     id: MarineDoctorIDCard
-    ears: ClothingHeadsetMedical
-  innerClothingSkirt: CMScrubsBlue
+    ears: CMHeadsetMedical
   satchel: ClothingBackpackSatchelMedicalFilled
-  duffelbag: ClothingBackpackDuffelMedicalFilled
 
 - type: entity
   id: CMSpawnPointDoctor

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Medical/nurse.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Medical/nurse.yml
@@ -10,8 +10,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-cm-cmo
   canBeAntag: true
-  #accessGroups:
-  #- CMMedical
+  accessGroups:
+  - CMMedical
 
 - type: startingGear
   id: NurseGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Medical/nurse.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Medical/nurse.yml
@@ -10,8 +10,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-cm-cmo
   canBeAntag: true
-  access:
-  - Medical
+  #accessGroups:
+  #- CMMedical
 
 - type: startingGear
   id: NurseGear
@@ -22,10 +22,8 @@
     shoes: CMShoesCombatBoots
     head: CMHeadCapSurgOrange
     id: NurseIDCard
-    ears: ClothingHeadsetMedical
-  innerClothingSkirt: CMScrubsNurse
+    ears: CMHeadsetMedical
   satchel: ClothingBackpackSatchelMedicalFilled
-  duffelbag: ClothingBackpackDuffelMedicalFilled
 
 - type: entity
   id: CMSpawnPointNurse

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Medical/researcher.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Medical/researcher.yml
@@ -14,11 +14,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-cm-cmo
   canBeAntag: true
-  access:
-  - Medical
-  - Chemistry
-  # Research
-  # Morgue
+  #accessGroups:
+  #- Researcher
 
 - type: startingGear
   id: ResearcherGear
@@ -28,10 +25,8 @@
     gloves: CMHandsLatex
     shoes: CMShoesCombatBoots
     id: ResearcherIDCard
-    ears: ClothingHeadsetMedical
-  innerClothingSkirt: CMJumpsuitResearch
+    ears: CMHeadsetResearcher
   satchel: ClothingBackpackSatchelMedicalFilled
-  duffelbag: ClothingBackpackDuffelMedicalFilled
 
 - type: entity
   id: CMSpawnPointResearcher

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Medical/researcher.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Medical/researcher.yml
@@ -14,8 +14,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-cm-cmo
   canBeAntag: true
-  #accessGroups:
-  #- Researcher
+  accessGroups:
+  - Researcher
 
 - type: startingGear
   id: ResearcherGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/MilitaryPolice/ChiefMilitaryPolice.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/MilitaryPolice/ChiefMilitaryPolice.yml
@@ -18,16 +18,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-command
   canBeAntag: false
-  access:
-  - HeadOfSecurity #CMP
-  - Command
-  - Brig
-  - Security
-  - Armory
-  - Maintenance
-  - External
-  - Engineering
-  - Medical
+  #accessGroups:
+  #- CMP
 
 - type: startingGear #todo cm14
   id: ChiefMPGear
@@ -40,11 +32,9 @@
     gloves: CMHandsBlack
     id: ChiefMPIDCard
     outerClothing: CMArmorM3WO
-    ears: ClothingHeadsetAltSecurity
+    ears: CMHeadsetCMP
     belt: ClothingBeltSecurityFilled
-  innerClothingSkirt: CMJumpsuitWO
   satchel: ClothingBackpackSatchelHOSFilled
-  duffelbag: ClothingBackpackDuffelHOSFilled
 
 - type: entity
   id: SpawnPointChiefMP

--- a/Resources/Prototypes/_CM14/Roles/Jobs/MilitaryPolice/ChiefMilitaryPolice.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/MilitaryPolice/ChiefMilitaryPolice.yml
@@ -18,8 +18,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-command
   canBeAntag: false
-  #accessGroups:
-  #- CMP
+  accessGroups:
+  - CMP
 
 - type: startingGear #todo cm14
   id: ChiefMPGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/MilitaryPolice/MilitaryPolice.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/MilitaryPolice/MilitaryPolice.yml
@@ -15,17 +15,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-militarywarden
   canBeAntag: false
-  access:
-  - Brig
-  - Command
-  - External # dropship?
-  #database
-  #prep
-  - Medical
-  # morgue
-  # alpha bravo charlie delta
-  - Engineering
-  - Maintenance
+  #accessGroups:
+  #- MP
 
 - type: startingGear
   id: MilitaryPoliceGear
@@ -38,11 +29,9 @@
     gloves: CMHandsBlack
     id: MilitaryPoliceIDCard
     outerClothing: CMArmorM2MP
-    ears: ClothingHeadsetSecurity
+    ears: CMHeadsetMPO
     belt: ClothingBeltSecurityFilled
-  innerClothingSkirt: CMJumpsuitMPBlack
   satchel: ClothingBackpackSatchelSecurityFilled
-  duffelbag: ClothingBackpackDuffelSecurityFilled
 
 - type: entity
   id: SpawnPointMilitaryPolice

--- a/Resources/Prototypes/_CM14/Roles/Jobs/MilitaryPolice/MilitaryPolice.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/MilitaryPolice/MilitaryPolice.yml
@@ -15,8 +15,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-militarywarden
   canBeAntag: false
-  #accessGroups:
-  #- MP
+  accessGroups:
+  - MP
 
 - type: startingGear
   id: MilitaryPoliceGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/MilitaryPolice/MilitaryWarden.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/MilitaryPolice/MilitaryWarden.yml
@@ -15,18 +15,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-chiefmp
   canBeAntag: false
-  access:
-  - Brig
-  - Command
-  - External # probably dropship
-  # database
-  # prep
-  - Armory
-  - Medical
-  # morgue
-  # alpha bravo charlie delta
-  - Engineering
-  - Maintenance
+  #accessGroups:
+  #- CMWarden
 
 - type: startingGear
   id: MilitaryWardenGear
@@ -39,11 +29,9 @@
     gloves: CMHandsBlack
     id: MilitaryWardenIDCard
     outerClothing: CMArmorM3Warden
-    ears: ClothingHeadsetAltSecurity
+    ears: CMHeadsetCMP
     belt: ClothingBeltSecurityFilled
-  innerClothingSkirt: CMJumpsuitWarden
   satchel: ClothingBackpackSatchelSecurityFilled
-  duffelbag: ClothingBackpackDuffelSecurityFilled
 
 - type: entity
   id: SpawnPointMilitaryWarden

--- a/Resources/Prototypes/_CM14/Roles/Jobs/MilitaryPolice/MilitaryWarden.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/MilitaryPolice/MilitaryWarden.yml
@@ -15,8 +15,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-chiefmp
   canBeAntag: false
-  #accessGroups:
-  #- CMWarden
+  accessGroups:
+  - CMWarden
 
 - type: startingGear
   id: MilitaryWardenGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Requisitions/CargoTech.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Requisitions/CargoTech.yml
@@ -10,8 +10,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-cm-quartermaster
   canBeAntag: true
-  #accessGroups:
-  # - CMCargoTech
+  accessGroups:
+  - CMCargoTech
 
 - type: startingGear
   id: CMCargoTechGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Requisitions/CargoTech.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Requisitions/CargoTech.yml
@@ -10,9 +10,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-cm-quartermaster
   canBeAntag: true
-  access:
-  - Cargo
-  # prep
+  #accessGroups:
+  # - CMCargoTech
 
 - type: startingGear
   id: CMCargoTechGear
@@ -23,10 +22,8 @@
     head: CMHeadCapCargo
     gloves: CMHandsBrown
     id: CMCargoTechIDCard
-    ears: ClothingHeadsetCargo
-  innerClothingSkirt: CMJumpsuitCargoTech
+    ears: CMHeadsetRequisition
   satchel: ClothingBackpackSatchelCargoFilled
-  duffelbag: ClothingBackpackDuffelCargoFilled
 
 - type: entity
   id: CMSpawnPointCargoTech

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Requisitions/MessTech.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Requisitions/MessTech.yml
@@ -10,8 +10,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-cm-quartermaster
   canBeAntag: true
-  access:
-  - Kitchen
+  #accessGroups:
+  #- MessTech
 
 - type: startingGear
   id: MessTechGear
@@ -22,10 +22,8 @@
     back: ClothingBackpackFilled
     shoes: CMShoesCombatBootsBrown
     id: MessTechIDCard
-    ears: ClothingHeadsetCargo
-  innerClothingSkirt: CMJumpsuitMessTech
+    ears: CMHeadsetChef
   satchel: ClothingBackpackSatchelFilled
-  duffelbag: ClothingBackpackDuffelFilled
 
 - type: entity
   id: SpawnPointMessTech

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Requisitions/MessTech.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Requisitions/MessTech.yml
@@ -10,8 +10,8 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-cm-quartermaster
   canBeAntag: true
-  #accessGroups:
-  #- MessTech
+  accessGroups:
+  - MessTech
 
 - type: startingGear
   id: MessTechGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Requisitions/Quartermaster.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Requisitions/Quartermaster.yml
@@ -16,7 +16,7 @@
   supervisors: job-supervisors-command
   canBeAntag: false
   accessGroups:
-  - CEQM
+  - CMQM
 
 - type: startingGear
   id: CMQuartermasterGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Requisitions/Quartermaster.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Requisitions/Quartermaster.yml
@@ -13,10 +13,10 @@
   icon: "JobIconCMQuartermaster"
   requireAdminNotify: false
   joinNotifyCrew: true
-  supervisors: job-supervisors-command #TODO CM14
+  supervisors: job-supervisors-command
   canBeAntag: false
   #accessGroups:
-  #- CEQM
+  - CEQM
 
 - type: startingGear
   id: CMQuartermasterGear

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Requisitions/Quartermaster.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Requisitions/Quartermaster.yml
@@ -14,13 +14,9 @@
   requireAdminNotify: false
   joinNotifyCrew: true
   supervisors: job-supervisors-command #TODO CM14
-  canBeAntag: true
-  access:
-  - Command
-  - Quartermaster
-  - Cargo
-  # prep
-  # alpha bravo charlie delta
+  canBeAntag: false
+  #accessGroups:
+  #- CEQM
 
 - type: startingGear
   id: CMQuartermasterGear
@@ -31,10 +27,8 @@
     head: CMHeadCapCargo
     gloves: CMHandsBrown
     id: CMQuartermasterIDCard
-    ears: ClothingHeadsetAltCargo
-  innerClothingSkirt: CMJumpsuitQM
+    ears: CMHeadsetQM
   satchel: ClothingBackpackSatchelQuartermasterFilled
-  duffelbag: ClothingBackpackDuffelQuartermasterFilled
 
 - type: entity
   id: CMSpawnPointQuartermaster

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Requisitions/Quartermaster.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Requisitions/Quartermaster.yml
@@ -15,7 +15,7 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-command
   canBeAntag: false
-  #accessGroups:
+  accessGroups:
   - CEQM
 
 - type: startingGear


### PR DESCRIPTION
## About the PR
gives all roles cm headsets
takes from all roles duffelbags
adds colony headset and colonist id card.
adds theirs accessGroups to all roles.

- requires #612 
- partially handles #30 
- fix role issues:
    - fix #32 
        - fix  #33 
            - fix #35
        - fix #37 
            - fix #39
        - fix #41 
            - fix #43
        - fix #45
            - fix #47
    - fix #49
        - fix #54 
            - fix #59
        - fix #55
            - fix #63
        - fix #56
            - fix #67
        - fix #57 
            - fix #71
    - fix #74 
        - fix #75 
            - fix #80
        - fix #76 
            - fix #83
        - fix #77
            - fix #87
     - fix #91 
         - fix #92 
           - fix #100
         - fix #93 
           - fix #104
         - fix #94 
           - fix #108
         - fix #95 
           - fix #112
         - fix #96
           - fix #116
         - fix #97 
           - fix #120
         - fix #98
           - fix #124
  - fix #127 
      - fix #128 
        - fix #132
      - fix #129 
        - fix #138
      - fix #130  
        - fix #142
   - fix #145
     - fix #146 
       - fix #151
     - fix #147 
       - fix #155
     - fix #148 
       - fix #159
     - fix #149
       - fix #163
    - fix #166 
      - fix #167 
        - fix #171
      - fix #168 
        - fix #175
      - fix #169
        - fix #179
    - fix some non-uscm roles (Second reporter role was added)
      - fix #184 
        - fix #188
      - fix #185
        - fix #192
      

## Why / Balance
radios because they need to hear, duh
duffels cause there`s no duffels in cm13