### PR TITLE
Add defender tail sweep ability, knockback, stun and effects

### DIFF
--- a/Content.Shared/_CM14/Xenos/Crest/XenoCrestSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Crest/XenoCrestSystem.cs
@@ -1,6 +1,8 @@
 ﻿using Content.Shared._CM14.Xenos.Armor;
+using Content.Shared._CM14.Xenos.Sweep;
 using Content.Shared.Actions;
 using Content.Shared.Movement.Systems;
+using Content.Shared.Popups;
 using Content.Shared.StatusEffect;
 
 namespace Content.Shared._CM14.Xenos.Crest;
@@ -10,6 +12,7 @@ public sealed class XenoCrestSystem : EntitySystem
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     public override void Initialize()
     {
@@ -17,6 +20,7 @@ public sealed class XenoCrestSystem : EntitySystem
         SubscribeLocalEvent<XenoCrestComponent, RefreshMovementSpeedModifiersEvent>(OnXenoCrestRefreshMovementSpeed);
         SubscribeLocalEvent<XenoCrestComponent, XenoGetArmorEvent>(OnXenoCrestGetArmor);
         SubscribeLocalEvent<XenoCrestComponent, BeforeStatusEffectAddedEvent>(OnXenoCrestBeforeStatusAdded);
+        SubscribeLocalEvent<XenoCrestComponent, XenoTailSweepAttemptEvent>(OnXenoCrestTailSweepAttempt);
 
         SubscribeLocalEvent<XenoCrestActionComponent, XenoCrestToggledEvent>(OnXenoCrestActionToggled);
     }
@@ -58,6 +62,15 @@ public sealed class XenoCrestSystem : EntitySystem
     {
         if (xeno.Comp.Lowered && args.Key == "Stun")
             args.Cancelled = true;
+    }
+
+    private void OnXenoCrestTailSweepAttempt(Entity<XenoCrestComponent> ent, ref XenoTailSweepAttemptEvent args)
+    {
+        if (ent.Comp.Lowered)
+        {
+            args.Cancelled = true;
+            _popup.PopupClient(Loc.GetString("cm-xeno-tail-sweep-crest"), ent, ent);
+        }
     }
 
     private void OnXenoCrestActionToggled(Entity<XenoCrestActionComponent> action, ref XenoCrestToggledEvent args)

--- a/Content.Shared/_CM14/Xenos/Melee/SharedXenoMeleeSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Melee/SharedXenoMeleeSystem.cs
@@ -89,6 +89,7 @@ public abstract class SharedXenoMeleeSystem : EntitySystem
             uid => uid == xeno.Owner || !HasComp<MobStateComponent>(uid), false));
         var results = intersect.Select(r => r.HitEntity).ToList();
 
+        // TODO CM14 no friendly fire
         // TODO CM14 sounds
         // TODO CM14 lag compensation
         var damage = new DamageSpecifier(xeno.Comp.TailDamage);

--- a/Content.Shared/_CM14/Xenos/Sweep/XenoSweepingComponent.cs
+++ b/Content.Shared/_CM14/Xenos/Sweep/XenoSweepingComponent.cs
@@ -1,0 +1,28 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._CM14.Xenos.Sweep;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(XenoTailSweepSystem))]
+public sealed partial class XenoSweepingComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public Direction? LastDirection;
+
+    [DataField, AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan Delay = TimeSpan.FromSeconds(0.07);
+
+    [DataField, AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan NextRotation;
+
+    [DataField, AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public int TotalRotations;
+
+    [DataField, AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public int MaxRotations = 4;
+}

--- a/Content.Shared/_CM14/Xenos/Sweep/XenoTailSweepActionEvent.cs
+++ b/Content.Shared/_CM14/Xenos/Sweep/XenoTailSweepActionEvent.cs
@@ -1,0 +1,7 @@
+﻿using Content.Shared.Actions;
+
+namespace Content.Shared._CM14.Xenos.Sweep;
+
+public sealed partial class XenoTailSweepActionEvent : InstantActionEvent
+{
+}

--- a/Content.Shared/_CM14/Xenos/Sweep/XenoTailSweepAttemptEvent.cs
+++ b/Content.Shared/_CM14/Xenos/Sweep/XenoTailSweepAttemptEvent.cs
@@ -1,0 +1,4 @@
+﻿namespace Content.Shared._CM14.Xenos.Sweep;
+
+[ByRefEvent]
+public record struct XenoTailSweepAttemptEvent(bool Cancelled);

--- a/Content.Shared/_CM14/Xenos/Sweep/XenoTailSweepComponent.cs
+++ b/Content.Shared/_CM14/Xenos/Sweep/XenoTailSweepComponent.cs
@@ -1,0 +1,40 @@
+﻿using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._CM14.Xenos.Sweep;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(XenoTailSweepSystem))]
+public sealed partial class XenoTailSweepComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public FixedPoint2 PlasmaCost = 10;
+
+    [DataField, AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public float Range = 1;
+
+    [DataField]
+    public DamageSpecifier? Damage;
+
+    // TODO CM14 scale with damage dealt up to a cap
+    [DataField, AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan StunTime = TimeSpan.FromSeconds(2);
+
+    [DataField, AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public SoundSpecifier Sound = new SoundCollectionSpecifier("XenoTailSwipe");
+
+    [DataField, AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public EntProtoId HitEffect = "CMEffectPunch";
+
+    [DataField, AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public SoundSpecifier HitSound = new SoundPathSpecifier("/Audio/_CM14/Xeno/alien_claw_block.ogg");
+}

--- a/Content.Shared/_CM14/Xenos/Sweep/XenoTailSweepSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Sweep/XenoTailSweepSystem.cs
@@ -1,0 +1,122 @@
+﻿using Content.Shared._CM14.Marines;
+using Content.Shared._CM14.Xenos.Plasma;
+using Content.Shared.Coordinates;
+using Content.Shared.Damage;
+using Content.Shared.Effects;
+using Content.Shared.Interaction;
+using Content.Shared.Stunnable;
+using Content.Shared.Throwing;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._CM14.Xenos.Sweep;
+
+public sealed class XenoTailSweepSystem : EntitySystem
+{
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedColorFlashEffectSystem _colorFlash = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
+    [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
+    [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly RotateToFaceSystem _rotateTo = default!;
+    [Dependency] private readonly SharedStunSystem _stun = default!;
+    [Dependency] private readonly ThrowingSystem _throwing = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
+
+    private readonly HashSet<Entity<MarineComponent>> _hit = new();
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<XenoTailSweepComponent, XenoTailSweepActionEvent>(OnXenoTailSweepAction);
+    }
+
+    private void OnXenoTailSweepAction(Entity<XenoTailSweepComponent> xeno, ref XenoTailSweepActionEvent args)
+    {
+        // TODO CM14 lag compensation
+        if (!TryComp(xeno, out TransformComponent? transform))
+            return;
+
+        var ev = new XenoTailSweepAttemptEvent();
+        RaiseLocalEvent(xeno, ref ev);
+
+        if (ev.Cancelled)
+            return;
+
+        if (!_xenoPlasma.TryRemovePlasmaPopup(xeno.Owner, xeno.Comp.PlasmaCost))
+            return;
+
+        args.Handled = true;
+
+        _audio.PlayPredicted(xeno.Comp.Sound, xeno, xeno);
+        EnsureComp<XenoSweepingComponent>(xeno);
+
+        if (_net.IsClient)
+            return;
+
+        _hit.Clear();
+        _entityLookup.GetEntitiesInRange(transform.Coordinates, 1.5f, _hit);
+
+        var origin = _transform.GetMapCoordinates(xeno);
+        foreach (var marine in _hit)
+        {
+            var marineCoords = _transform.GetMapCoordinates(marine);
+            var diff = marineCoords.Position - origin.Position;
+            diff *= xeno.Comp.Range / 3;
+
+            if (xeno.Comp.Damage is { } damage)
+                _damageable.TryChangeDamage(marine, damage);
+
+            var filter = Filter.Pvs(marine, entityManager: EntityManager);
+            _colorFlash.RaiseEffect(Color.Red, new List<EntityUid> { marine }, filter);
+
+            _throwing.TryThrow(marine, diff, 5);
+            _stun.TryKnockdown(marine, xeno.Comp.StunTime, true);
+            _stun.TryStun(marine, xeno.Comp.StunTime, true);
+
+            _audio.PlayPvs(xeno.Comp.HitSound, marine);
+            SpawnAttachedTo(xeno.Comp.HitEffect, marine.Owner.ToCoordinates());
+        }
+    }
+
+    public override void Update(float frameTime)
+    {
+        var query = EntityQueryEnumerator<XenoSweepingComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var sweeping, out var xform))
+        {
+            if (sweeping.NextRotation > _timing.CurTime)
+                continue;
+
+            if (sweeping.TotalRotations >= sweeping.MaxRotations)
+            {
+                RemCompDeferred<XenoSweepingComponent>(uid);
+                continue;
+            }
+
+            sweeping.TotalRotations++;
+            sweeping.NextRotation = _timing.CurTime + sweeping.Delay;
+            sweeping.LastDirection ??= _transform.GetWorldRotation(xform).GetDir();
+
+            var nextAngle = sweeping.LastDirection.Value.ToAngle() + Angle.FromDegrees(90);
+            sweeping.LastDirection = nextAngle.GetDir();
+
+            Dirty(uid, sweeping);
+
+            _rotateTo.TryFaceAngle(uid, nextAngle, xform);
+        }
+    }
+
+    public override void FrameUpdate(float frameTime)
+    {
+        var query = EntityQueryEnumerator<XenoSweepingComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var sweeping, out var xform))
+        {
+            if (sweeping.LastDirection is not { } direction)
+                continue;
+
+            _rotateTo.TryFaceAngle(uid, direction.ToAngle(), xform);
+        }
+    }
+}

--- a/Resources/Locale/en-US/_CM14/xeno/xeno-abilities.ftl
+++ b/Resources/Locale/en-US/_CM14/xeno/xeno-abilities.ftl
@@ -36,6 +36,9 @@ cm-xeno-pheromones-stop = You stop emitting pheromones
 # Regurgitate
 cm-xeno-none-devoured = You haven't devoured anyone!
 
+# Tail Sweep
+cm-xeno-tail-sweep-crest = You can't tail swipe with your crest lowered!
+
 # Transfer Plasma
 cm-xeno-plasma-transferred-to-other = You have transferred {$plasma} plasma to {$target}. You now have {$total}
 cm-xeno-plasma-transferred-to-self = {$target} has transferred {$plasma} plasma to you. You now have {$total}

--- a/Resources/Prototypes/_CM14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_CM14/Actions/Xeno/xeno_offense_actions.yml
@@ -79,4 +79,3 @@
       state: tail_sweep
     event: !type:XenoTailSweepActionEvent
     useDelay: 15
-    checkCanAccess: false

--- a/Resources/Prototypes/_CM14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_CM14/Actions/Xeno/xeno_offense_actions.yml
@@ -66,3 +66,17 @@
     range: 15
     useDelay: 6
     checkCanAccess: false
+
+- type: entity
+  id: ActionXenoTailSweep
+  parent: ActionXenoBase
+  name: Tail Sweep # TODO CM14 description
+  components:
+  - type: InstantAction
+    itemIconStyle: NoItem
+    icon:
+      sprite: _CM14/Actions/xeno_actions.rsi
+      state: tail_sweep
+    event: !type:XenoTailSweepActionEvent
+    useDelay: 15
+    checkCanAccess: false

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/defender.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/defender.yml
@@ -23,6 +23,7 @@
     - ActionXenoTailStab # TODO CM14 name it "tail slam"
     - ActionXenoToggleCrest
     - ActionXenoHeadbutt
+    - ActionXenoTailSweep
     plasma: 100 # TODO CM14
     maxPlasma: 100
     plasmaRegenOnWeeds: 6
@@ -34,3 +35,7 @@
       types:
         Blunt: 30 # TODO CM14 penetrating damage
   - type: XenoAnimateMovement
+  - type: XenoTailSweep
+    damage:
+      types:
+        Slash: 30


### PR DESCRIPTION
## About the PR
Resolves #384 

## Media
https://github.com/CM-14/CM-14/assets/10968691/d4580cbf-8379-4593-b9e7-933367019478

---

Blocked from use if the defender's crest is lowered:

https://github.com/CM-14/CM-14/assets/10968691/825718d3-ed70-4dcc-b1dd-929a715b9d39

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
