### PR TITLE
Fix medical belt whitelist

### DIFF
--- a/Resources/Prototypes/_CM14/Entities/Objects/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_CM14/Entities/Objects/Clothing/Belt/belts.yml
@@ -147,6 +147,9 @@
       - Syringe
       # surgical line
       - Bloodpack
+      - Brutepack
+      - Gauze
+      - Ointment
       components:
       - Hypospray
       - Defibrillator


### PR DESCRIPTION
## About the PR
Adds brute, ointment and gauze to the medical belt whitelist.