### PR TITLE
Fixed improper barbed wire to door sprites for barricade

### DIFF
--- a/Resources/Prototypes/_CM14/Entities/Structures/Walls/barricade_metal.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Walls/barricade_metal.yml
@@ -314,9 +314,9 @@
     visuals:
       enum.BarbedWireVisualLayers.Wire:
         barbWired:
-          UnWired: { state: folding_metal_wire, visible: false }
-          WiredClosed: { state: folding_metal_closed_wire, visible: true }
-          WiredOpen: { state: folding_metal_wire, visible: true }
+          UnWired: { state: folding_metal_closed_wire, visible: false }
+          WiredClosed: { state: folding_metal_wire, visible: true }
+          WiredOpen: { state: folding_metal_closed_wire, visible: true }
   - type: InteractionOutline
   - type: Door
     openSpriteState: folding_metal_closed
@@ -379,9 +379,9 @@
     visuals:
       enum.BarbedWireVisualLayers.Wire:
         barbWired:
-          UnWired: { state: plasteel_wire, visible: false }
-          WiredClosed: { state: plasteel_closed_wire, visible: true }
-          WiredOpen: { state: plasteel_wire, visible: true }
+          UnWired: { state: plasteel_closed_wire, visible: false }
+          WiredClosed: { state: plasteel_wire, visible: true }
+          WiredOpen: { state: plasteel_closed_wire, visible: true }
   - type: Door
     openSpriteState: plasteel_closed
     closedSpriteState: plasteel


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Super duper fast fix to barricade doors so the door sprites and barbed sprites line up properly.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
