### PR TITLE
Pouch fix

### DIFF
--- a/Resources/Prototypes/_CM14/Entities/Clothing/pouches.yml
+++ b/Resources/Prototypes/_CM14/Entities/Clothing/pouches.yml
@@ -1,4 +1,5 @@
 - type: entity
+  parent: Clothing
   id: CMPouch #i know that there are no pouches in upstream, but having "CM" helps finding that item in entity spawner
   name: abstract pouch
   description: The physical manifestation of a concept of a pouch. Woah.


### PR DESCRIPTION
## About the PR

Pouches had only CMEntityBase as parent (maybe), so when we deleted it - all pouches lost Clickable and Interaction Outline components.

This PR fixes it.
