### PR TITLE
Fixed matchbox id

### DIFF
--- a/Resources/Prototypes/_CM14/Entities/Objects/Consumables/Smokeables/matchbooks.yml
+++ b/Resources/Prototypes/_CM14/Entities/Objects/Consumables/Smokeables/matchbooks.yml
@@ -87,7 +87,7 @@
 
 - type: entity
   parent: CMMatchBook
-  id: CMExecutiveWYMatchbookCMExecutiveWYMatchbook
+  id: CMExecutiveWYMatchbook
   name: Weyland-Yutani gold matchbook
   description: A small book of expensive paper matches. These ones light almost every time, or so the packaging claims.
   components:


### PR DESCRIPTION
## About the PR

WY gold matchbox, had doubled id - CMExecutiveWYMatchboxCMExecutiveWYMatchbox. This PR fixes it.