### PR TITLE
Disable Suicide

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -1663,6 +1663,12 @@ namespace Content.Shared.CCVar
         public static readonly CVarDef<bool> ICShowSSDIndicator =
             CVarDef.Create("ic.show_ssd_indicator", true, CVar.CLIENTONLY);
 
+        /// <summary>
+        /// Controls whether or not suiciding is allowed. This does not control ghosting.
+        /// </summary>
+        public static readonly CVarDef<bool> ICEnableSuicide =
+            CVarDef.Create("ic.enable_suicide", false, CVar.SERVER);
+
         /*
          * Salvage
          */


### PR DESCRIPTION
Doing /suicide will now result in ghosting by default.

## Why / Balance
Resolves #970.

## Technical details
Adds a new CVar which controls global suicide behaviour. I considered adding the `CannotSuicide` tag to everything, but this is easier and prevents tech debt. Another option is to have a tag which is needed to enable suiciding, like `CanSuicide`. Both options work.

## Media

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Simyon
- tweak: Suiciding will now result in ghosting, keeping your body alive.