### PR TITLE
Automatically expand the space of any storages that are too small on spawn, adjust item sizes

### DIFF
--- a/Content.IntegrationTests/Tests/StorageTest.cs
+++ b/Content.IntegrationTests/Tests/StorageTest.cs
@@ -128,7 +128,8 @@ namespace Content.IntegrationTests.Tests
                     if (maxSize == null)
                         continue;
 
-                    Assert.That(size, Is.LessThanOrEqualTo(storage.Grid.GetArea()), $"{proto.ID} storage fill is too large.");
+                    // CM14: This is automatically expanded
+                    // Assert.That(size, Is.LessThanOrEqualTo(storage.Grid.GetArea()), $"{proto.ID} storage fill is too large.");
 
                     foreach (var entry in fill.Contents)
                     {

--- a/Content.Server/Storage/EntitySystems/StorageSystem.Fill.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.Fill.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Server.Spawners.Components;
 using Content.Server.Storage.Components;
+using Content.Shared._CM14.Storage;
 using Content.Shared.Item;
 using Content.Shared.Prototypes;
 using Content.Shared.Storage;
@@ -67,6 +68,9 @@ public sealed partial class StorageSystem
 
         foreach (var ent in sortedItems)
         {
+            var ev = new CMStorageItemFillEvent(ent, storage);
+            RaiseLocalEvent(entity, ref ev);
+
             if (Insert(uid, ent, out _, out var reason, storageComp: storage, playSound: false))
                 continue;
 

--- a/Content.Shared/_CM14/Storage/CMStorageItemFillEvent.cs
+++ b/Content.Shared/_CM14/Storage/CMStorageItemFillEvent.cs
@@ -1,0 +1,7 @@
+﻿using Content.Shared.Item;
+using Content.Shared.Storage;
+
+namespace Content.Shared._CM14.Storage;
+
+[ByRefEvent]
+public record struct CMStorageItemFillEvent(Entity<ItemComponent> Item, StorageComponent Storage);

--- a/Content.Shared/_CM14/Storage/CMStorageSystem.cs
+++ b/Content.Shared/_CM14/Storage/CMStorageSystem.cs
@@ -19,6 +19,7 @@ public sealed class CMStorageSystem : EntitySystem
         if (!_storage.CanInsert(storage, args.Item, out var reason) &&
             reason == "comp-storage-insufficient-capacity")
         {
+            // TODO CM14 make this error if this is a cm-specific storage
             Log.Warning($"Storage {ToPrettyString(storage)} can't fit {ToPrettyString(args.Item)}");
 
             var modified = false;

--- a/Content.Shared/_CM14/Storage/CMStorageSystem.cs
+++ b/Content.Shared/_CM14/Storage/CMStorageSystem.cs
@@ -21,6 +21,7 @@ public sealed class CMStorageSystem : EntitySystem
         {
             Log.Warning($"Storage {ToPrettyString(storage)} can't fit {ToPrettyString(args.Item)}");
 
+            var modified = false;
             foreach (var shape in _item.GetItemShape((args.Item, args.Item)))
             {
                 var grid = args.Storage.Grid;
@@ -37,7 +38,11 @@ public sealed class CMStorageSystem : EntitySystem
                     expanded.Top = shape.Top;
 
                 grid[^1] = expanded;
+                modified = true;
             }
+
+            if (modified)
+                Dirty(storage);
         }
     }
 }

--- a/Resources/Prototypes/_CM14/Entities/Clothing/pouches.yml
+++ b/Resources/Prototypes/_CM14/Entities/Clothing/pouches.yml
@@ -17,7 +17,7 @@
     slots:
     - pocket
   - type: Storage
-    maxItemSize: Small
+    maxItemSize: Normal
     grid:
     - 0,0,1,1 #1 slot
     blacklist:
@@ -147,6 +147,8 @@
       # todo cm14 splint
       - Radio
       - Knife
+      - CMTraumaKit
+      - CMBurnKit
 
 - type: entity
   parent: CMPouchSurvival
@@ -185,6 +187,9 @@
       - PillCanister
       - Brutepack
       # todo cm14 splint
+      - CMTraumaKit
+      - CMBurnKit
+      - CMAutoInjector
 
 - type: entity
   parent: CMPouchFirstAid
@@ -490,6 +495,8 @@
       # Roller
       - BodyBag
       - Bloodpack
+      - CMTraumaKit
+      - CMBurnKit
       components:
       - Hypospray
 

--- a/Resources/Prototypes/_CM14/Entities/Objects/Medical/auto_injectors.yml
+++ b/Resources/Prototypes/_CM14/Entities/Objects/Medical/auto_injectors.yml
@@ -34,7 +34,8 @@
     solution: pen
     reagents: {}
   - type: Tag
-    tags: []
+    tags:
+    - CMAutoInjector
 
 - type: entity
   parent: CMAutoInjector

--- a/Resources/Prototypes/_CM14/tags.yml
+++ b/Resources/Prototypes/_CM14/tags.yml
@@ -64,6 +64,8 @@
 - type: Tag
   id: CMMagazinePistol88m4AP
 
-
 - type: Tag
   id: LauncherCompatibleGrenade
+
+- type: Tag
+  id: CMAutoInjector

--- a/Resources/Prototypes/item_size.yml
+++ b/Resources/Prototypes/item_size.yml
@@ -4,7 +4,7 @@
   weight: 1
   name: item-component-size-Tiny
   defaultShape:
-  - 0,0,0,0
+  - 0,0,0,1
 
 # Items that can fit inside of a standard pocket.
 - type: itemSize
@@ -12,7 +12,7 @@
   weight: 2
   name: item-component-size-Small
   defaultShape:
-  - 0,0,0,1
+  - 0,0,1,1
 
 # Items that can fit inside of a standard bag.
 - type: itemSize
@@ -20,7 +20,7 @@
   weight: 4
   name: item-component-size-Normal
   defaultShape:
-  - 0,0,1,1
+  - 0,0,2,1
 
 # Items that are too large to fit inside of standard bags, but can worn in exterior slots or placed in custom containers.
 - type: itemSize
@@ -36,7 +36,7 @@
   weight: 16
   name: item-component-size-Huge
   defaultShape:
-  - 0,0,3,3
+  - 0,0,4,1
 
 # Picture furry gf
 - type: itemSize
@@ -44,4 +44,4 @@
   weight: 32
   name: item-component-size-Ginormous
   defaultShape:
-  - 0,0,5,5
+  - 0,0,5,1


### PR DESCRIPTION
## About the PR
It now warns instead of erroring.
This doesn't distinguish between upstream and cm inventories but it should some day, so that we know when a cm inventory is setup wrong.

## Media
![image](https://github.com/CM-14/CM-14/assets/10968691/fcfdb457-b37f-4e4d-805c-cd54867ba0d6)
![image](https://github.com/CM-14/CM-14/assets/10968691/972980c3-3927-49f7-8466-652a014a6ec9)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

