### PR TITLE
Fix multiplier issues with marine orders

### DIFF
--- a/Content.Shared/_CM14/Marines/Orders/FocusOrderComponent.cs
+++ b/Content.Shared/_CM14/Marines/Orders/FocusOrderComponent.cs
@@ -15,11 +15,11 @@ public sealed partial class FocusOrderComponent : Component, IOrderComponent
     // CM14 TODO Make this do something when/if you will ever be able to modify the deviation of bullets with an event
     // or something. Trying to do it now would be possible but would then deviate from upstream stuff.
     [DataField, AutoNetworkedField]
-    public FixedPoint2 AccuracyModifier = 0.1;
+    public FixedPoint2 AccuracyModifier = 1.1;
 
     //CM14 TODO Make this do something when/if weapons ever get range.
     [DataField, AutoNetworkedField]
-    public FixedPoint2 RangeModifier = 0.1;
+    public FixedPoint2 RangeModifier = 1.1;
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
     public TimeSpan Duration { get; set; }

--- a/Content.Shared/_CM14/Marines/Orders/HoldOrderComponent.cs
+++ b/Content.Shared/_CM14/Marines/Orders/HoldOrderComponent.cs
@@ -21,7 +21,7 @@ public sealed partial class HoldOrderComponent : Component, IOrderComponent
     /// Resistance to damage.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public FixedPoint2 DamageModifier;
+    public FixedPoint2 DamageModifier = 0.95;
 
     [DataField]
     public List<ProtoId<DamageTypePrototype>> DamageTypes = new() { "Slash", "Blunt" };

--- a/Content.Shared/_CM14/Marines/Orders/MarineOrdersComponent.cs
+++ b/Content.Shared/_CM14/Marines/Orders/MarineOrdersComponent.cs
@@ -24,6 +24,7 @@ public sealed partial class MarineOrdersComponent : Component
     /// The range of the order's effect.
     /// </summary>
     [DataField, AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadWrite)]
     public int OrderRange = 8;
 
 
@@ -38,6 +39,7 @@ public sealed partial class MarineOrdersComponent : Component
     /// Higher is more intense.
     /// </summary>
     [DataField, AutoNetworkedField]
+    [ViewVariables(VVAccess.ReadWrite)]
     public FixedPoint2 Multiplier = 1;
 
 

--- a/Content.Shared/_CM14/Marines/Orders/MoveOrderComponent.cs
+++ b/Content.Shared/_CM14/Marines/Orders/MoveOrderComponent.cs
@@ -13,11 +13,11 @@ public sealed partial class MoveOrderComponent : Component, IOrderComponent
     public SpriteSpecifier Icon = new Rsi(new ResPath("/Textures/_CM14/Interface/marine_orders.rsi"), "move");
 
     [DataField, AutoNetworkedField]
-    public FixedPoint2 MoveSpeedModifier = 0.1;
+    public FixedPoint2 MoveSpeedModifier = 1.1;
 
     // CM14 TODO Actually make this do something once we got melee dodging
     [DataField, AutoNetworkedField]
-    public FixedPoint2 DodgeModifier = 0.1;
+    public FixedPoint2 DodgeModifier = 1.1;
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
     public TimeSpan Duration { get; set; }

--- a/Content.Shared/_CM14/Marines/Orders/SharedMarineOrdersSystem.cs
+++ b/Content.Shared/_CM14/Marines/Orders/SharedMarineOrdersSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Actions;
 using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
 using Content.Shared.Movement.Systems;
 using Robust.Shared.GameStates;
 using Robust.Shared.Timing;
@@ -43,7 +44,7 @@ public abstract class SharedMarineOrdersSystem : EntitySystem
     private void OnDamageModify(EntityUid uid, HoldOrderComponent comp, DamageModifyEvent args)
     {
         var damage = args.Damage.DamageDict;
-        var multiplier = 1 + comp.DamageModifier;
+        var multiplier = 1 * comp.DamageModifier;
 
         foreach (var type in comp.DamageTypes)
         {
@@ -53,7 +54,7 @@ public abstract class SharedMarineOrdersSystem : EntitySystem
     }
     private void OnRefreshMovement(EntityUid uid, MoveOrderComponent comp, RefreshMovementSpeedModifiersEvent args)
     {
-        var speed = (1 + comp.MoveSpeedModifier).Float();
+        var speed = (1 * comp.MoveSpeedModifier).Float();
         args.ModifySpeed(speed, speed);
     }
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
This PR fixes what I can only describe as an unfathomable skill issue on my part when I originally wrote this code. Which I can only attribute to sleep deprivation and stupidity. 

The way modifiers were applied for the hold older made is so you received MORE damage. 

This pr also standardizes the way orders apply their modifier. 

Lastly it just makes some fields in the marineorders component VVWrite which may be useful for admins.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It bug.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Now all modifiers are applied as original_value * (1 * modifier).

Also orders have default values properly.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
N/A
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun