### PR TITLE
Fix moving entities leaving the corrosive acid effect behind

### DIFF
--- a/Content.Shared/_CM14/Xenos/Acid/XenoAcidSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Acid/XenoAcidSystem.cs
@@ -13,6 +13,7 @@ public sealed class XenoAcidSystem : EntitySystem
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly XenoPlasmaSystem _xenoPlasma = default!;
 
     public override void Initialize()
@@ -55,7 +56,8 @@ public sealed class XenoAcidSystem : EntitySystem
 
         args.Handled = true;
 
-        var acid = SpawnAttachedTo(args.AcidId, target.ToCoordinates());
+        var acid = SpawnAtPosition(args.AcidId, target.ToCoordinates());
+        _transform.SetParent(acid, target);
         AddComp(target, new CorrodingComponent
         {
             Acid = acid,

--- a/Resources/Prototypes/_CM14/Effects/xeno_acid.yml
+++ b/Resources/Prototypes/_CM14/Effects/xeno_acid.yml
@@ -3,7 +3,6 @@
   name: corrosive acid
   components:
   - type: Transform
-    anchored: true
   - type: Sprite
     layers:
     - sprite: _CM14/Effects/xeno_acid.rsi


### PR DESCRIPTION
## About the PR
Fixes #1201 

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed moving corroding objects leaving the acid visual effect behind.
