### PR TITLE
Glass shards don't hurt xenos and humans

### DIFF
--- a/Resources/Prototypes/_CM14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Species/base.yml
@@ -6,6 +6,9 @@
   name: Urist C.M. McHands
   suffix: CM14
   components:
+  - type: Tag
+    tags:
+    - ShoesRequiredStepTriggerImmune
   - type: Marine
   - type: Hunger
   - type: Thirst

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/base_xeno.yml
@@ -3,6 +3,9 @@
   abstract: true
   save: false
   components:
+  - type: Tag
+    tags:
+    - ShoesRequiredStepTriggerImmune
   - type: Damageable
     damageContainer: Biological
   - type: Destructible
@@ -233,6 +236,7 @@
   - type: Tag
     tags:
     - DoorBumpOpener
+    - ShoesRequiredStepTriggerImmune
   - type: Hands
   - type: GiveHands
     hands:


### PR DESCRIPTION
- fix #1158 

:cl: Whisper

- tweak: Xenos (and humanoids) no longer trigger stepping on glass shards

