### PR TITLE
Fix incorrect sizes in night vision overlay

### DIFF
--- a/Content.Client/_CM14/NightVision/NightVisionOverlay.cs
+++ b/Content.Client/_CM14/NightVision/NightVisionOverlay.cs
@@ -1,5 +1,4 @@
-﻿using System.Numerics;
-using Content.Shared._CM14.NightVision;
+﻿using Content.Shared._CM14.NightVision;
 using Content.Shared.Mobs.Components;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
@@ -16,7 +15,7 @@ public sealed class NightVisionOverlay : Overlay
 
     private readonly TransformSystem _transform;
 
-    public override OverlaySpace Space => OverlaySpace.ScreenSpace;
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
 
     public NightVisionOverlay()
     {
@@ -33,22 +32,20 @@ public sealed class NightVisionOverlay : Overlay
             return;
         }
 
+        var handle = args.WorldHandle;
         var eye = args.Viewport.Eye;
         var eyeRot = eye?.Rotation ?? default;
-        var zoom = Vector2.One / (args.Viewport.Eye?.Zoom ?? Vector2.One);
 
         var entities = _entity.EntityQueryEnumerator<MobStateComponent, SpriteComponent, TransformComponent>();
-        while (entities.MoveNext(out var uid, out _, out var sprite, out var xform))
+        while (entities.MoveNext(out _, out var sprite, out var xform))
         {
             if (xform.MapID != eye?.Position.MapId)
                 continue;
 
-            var position = _eye.CoordinatesToScreen(xform.Coordinates).Position;
-            if (!args.ViewportBounds.Contains((int) position.X, (int) position.Y))
-                continue;
-
+            var position = xform.Coordinates.ToMapPos(_entity, _transform);
             var rotation = _transform.GetWorldRotation(xform);
-            args.ScreenHandle.DrawEntity(uid, position, Vector2.One * 2 * zoom, rotation + eyeRot, Angle.Zero, null, sprite, xform, _transform);
+
+            sprite.Render(handle, eyeRot, rotation, position: position);
         }
     }
 }


### PR DESCRIPTION
## About the PR
Previously if you resized the viewport or window it would make the overlayed sizes not match the actual sprite sizes.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

