### PR TITLE
Make pump shotguns delay after shooting instead of pumping, examine text, popups when not able to shoot

### DIFF
--- a/Content.Client/_CM14/Weapons/Ranged/PumpActionSystem.cs
+++ b/Content.Client/_CM14/Weapons/Ranged/PumpActionSystem.cs
@@ -1,0 +1,35 @@
+﻿using Content.Shared._CM14.Input;
+using Content.Shared._CM14.Weapons.Ranged;
+using Content.Shared.Examine;
+using Content.Shared.Popups;
+using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Client.Input;
+
+namespace Content.Client._CM14.Weapons.Ranged;
+
+public sealed class PumpActionSystem : SharedPumpActionSystem
+{
+    [Dependency] private readonly IInputManager _input = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    protected override void OnExamined(Entity<PumpActionComponent> ent, ref ExaminedEvent args)
+    {
+        if (!_input.TryGetKeyBinding(CMKeyFunctions.CMPumpShotgun, out var bind))
+            return;
+
+        args.PushMarkup($"[bold]Press [color=cyan]{bind.GetKeyString()}[/color] to pump before shooting.[/bold]", 1);
+    }
+
+    protected override void OnAttemptShoot(Entity<PumpActionComponent> ent, ref AttemptShootEvent args)
+    {
+        base.OnAttemptShoot(ent, ref args);
+
+        if (!ent.Comp.Pumped)
+        {
+            var message = _input.TryGetKeyBinding(CMKeyFunctions.CMPumpShotgun, out var bind)
+                ? $"You need to pump the gun with {bind.GetKeyString()} first!"
+                : "You need to pump the gun first!";
+            _popup.PopupClient(message, args.User, args.User);
+        }
+    }
+}

--- a/Content.Server/_CM14/Weapons/Ranged/PumpActionSystem.cs
+++ b/Content.Server/_CM14/Weapons/Ranged/PumpActionSystem.cs
@@ -1,0 +1,5 @@
+﻿using Content.Shared._CM14.Weapons.Ranged;
+
+namespace Content.Server._CM14.Weapons.Ranged;
+
+public sealed class PumpActionSystem : SharedPumpActionSystem;

--- a/Content.Shared/_CM14/Weapons/Ranged/PumpActionComponent.cs
+++ b/Content.Shared/_CM14/Weapons/Ranged/PumpActionComponent.cs
@@ -4,8 +4,8 @@ using Robust.Shared.GameStates;
 namespace Content.Shared._CM14.Weapons.Ranged;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-[Access(typeof(CMPumpActionSystem))]
-public sealed partial class CMPumpActionComponent : Component
+[Access(typeof(SharedPumpActionSystem))]
+public sealed partial class PumpActionComponent : Component
 {
     [DataField, AutoNetworkedField]
     public bool Pumped;

--- a/Content.Shared/_CM14/Weapons/Ranged/SharedPumpActionSystem.cs
+++ b/Content.Shared/_CM14/Weapons/Ranged/SharedPumpActionSystem.cs
@@ -2,7 +2,9 @@
 using Content.Shared.ActionBlocker;
 using Content.Shared.Examine;
 using Content.Shared.Hands.Components;
+using Content.Shared.Popups;
 using Content.Shared.Verbs;
+using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Input.Binding;
@@ -13,6 +15,7 @@ public abstract class SharedPumpActionSystem : EntitySystem
 {
     [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     public override void Initialize()
     {
@@ -87,6 +90,15 @@ public abstract class SharedPumpActionSystem : EntitySystem
         if (TryComp(user, out HandsComponent? hands) &&
             TryComp(hands.ActiveHandEntity, out PumpActionComponent? pump))
         {
+            var ammo = new GetAmmoCountEvent();
+            RaiseLocalEvent(hands.ActiveHandEntity.Value, ref ammo);
+
+            if (ammo.Count <= 0)
+            {
+                _popup.PopupClient("You don't have any ammo left!", user, user);
+                return;
+            }
+
             TryPump(user, (hands.ActiveHandEntity.Value, pump));
         }
     }

--- a/Content.Shared/_CM14/Weapons/Ranged/ShootUseDelayComponent.cs
+++ b/Content.Shared/_CM14/Weapons/Ranged/ShootUseDelayComponent.cs
@@ -1,0 +1,13 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._CM14.Weapons.Ranged;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ShootUseDelayComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public TimeSpan LastPopup;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan PopupCooldown = TimeSpan.FromSeconds(0.333);
+}

--- a/Content.Shared/_CM14/Weapons/Ranged/ShootUseDelayComponent.cs
+++ b/Content.Shared/_CM14/Weapons/Ranged/ShootUseDelayComponent.cs
@@ -9,5 +9,5 @@ public sealed partial class ShootUseDelayComponent : Component
     public TimeSpan LastPopup;
 
     [DataField, AutoNetworkedField]
-    public TimeSpan PopupCooldown = TimeSpan.FromSeconds(0.333);
+    public TimeSpan PopupCooldown = TimeSpan.FromSeconds(0.5);
 }

--- a/Content.Shared/_CM14/Weapons/Ranged/ShootUseDelaySystem.cs
+++ b/Content.Shared/_CM14/Weapons/Ranged/ShootUseDelaySystem.cs
@@ -1,0 +1,44 @@
+﻿using Content.Shared.Popups;
+using Content.Shared.Timing;
+using Content.Shared.Weapons.Ranged.Events;
+using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._CM14.Weapons.Ranged;
+
+public sealed class ShootUseDelaySystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly UseDelaySystem _useDelay = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<ShootUseDelayComponent, ShotAttemptedEvent>(OnShotAttempted);
+        SubscribeLocalEvent<ShootUseDelayComponent, GunShotEvent>(OnGunShot);
+    }
+
+    private void OnShotAttempted(Entity<ShootUseDelayComponent> ent, ref ShotAttemptedEvent args)
+    {
+        if (TryComp(ent, out UseDelayComponent? useDelay) &&
+            _useDelay.IsDelayed((ent, useDelay)))
+        {
+            var time = _timing.CurTime;
+            if (time >= ent.Comp.LastPopup + ent.Comp.PopupCooldown)
+            {
+                var timeLeft = useDelay.DelayEndTime - time;
+                ent.Comp.LastPopup = _timing.CurTime;
+                Dirty(ent);
+                _popup.PopupClient($"You need to wait {timeLeft.TotalSeconds:F1} seconds before shooting again!", args.User, args.User);
+            }
+
+            args.Cancel();
+        }
+    }
+
+    private void OnGunShot(Entity<ShootUseDelayComponent> ent, ref GunShotEvent args)
+    {
+        if (TryComp(ent, out UseDelayComponent? useDelay))
+            _useDelay.TryResetDelay((ent, useDelay), true);
+    }
+}

--- a/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Guns/Shotguns/uscm_shotguns.yml
+++ b/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Guns/Shotguns/uscm_shotguns.yml
@@ -2,7 +2,7 @@
   parent: BaseWeaponShotgun
   name: M37A2 Pump Shotgun
   id: WeaponShotgunM37A2
-  description: An Armat Battlefield Systems classic design, the M37A2 combines close-range firepower with long term reliability. Requires a pump, which is a Unique Action.
+  description: An Armat Battlefield Systems classic design, the M37A2 combines close-range firepower with long term reliability. Needs to be pumped.
   components:
   - type: Sprite
     sprite: _CM14/Objects/Weapons/Guns/Shotguns/m37a2.rsi
@@ -28,7 +28,8 @@
     proto: null
     soundInsert:
       path: /Audio/_CM14/Weapons/Guns/Reload/m37a2.ogg
-  - type: CMPumpAction
+  - type: PumpAction
+  - type: ShootUseDelay
   - type: UseDelay
     delay: 2
 


### PR DESCRIPTION
## About the PR
Shotgun polish for the marine players (I'm not one of them)
Fixes #1212 

## Media
https://github.com/CM-14/CM-14/assets/10968691/7b1c7a44-fb6f-413b-824c-2753ac730f11

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Added examine text to pump shotguns that tell you how to pump it.
- add: Added popups when the user is unable to shoot, either from needing to pump a shotgun or needing to wait before shooting again.
- tweak: Pump shotguns now have a delay between shots instead of a delay between pumps.
- fix: Pumping now requires the gun to have at least one bullet left.