### PR TITLE
Add a delay to opening big backpacks and close them on move

### DIFF
--- a/Content.Client/Inventory/ClientInventorySystem.cs
+++ b/Content.Client/Inventory/ClientInventorySystem.cs
@@ -201,7 +201,7 @@ namespace Content.Client.Inventory
 
         public void UIInventoryStorageActivate(string slot)
         {
-            EntityManager.EntityNetManager?.SendSystemNetworkMessage(new OpenSlotStorageNetworkMessage(slot));
+            EntityManager.RaisePredictiveEvent(new OpenSlotStorageNetworkMessage(slot));
         }
 
         public void UIInventoryExamine(string slot, EntityUid uid)

--- a/Content.Client/Storage/Systems/StorageSystem.cs
+++ b/Content.Client/Storage/Systems/StorageSystem.cs
@@ -173,4 +173,11 @@ public sealed class StorageSystem : SharedStorageSystem
             }
         }
     }
+
+    public override void OpenStorageUI(EntityUid uid, EntityUid entity, StorageComponent? storageComp = null, bool silent = false,
+        bool doAfter = true)
+    {
+        if (doAfter && CMStorage.OpenDoAfter(uid, entity, storageComp, silent))
+            return;
+    }
 }

--- a/Content.Server/Inventory/ServerInventorySystem.cs
+++ b/Content.Server/Inventory/ServerInventorySystem.cs
@@ -1,24 +1,15 @@
-using Content.Server._CM14.Webbing;
-using Content.Server.Storage.EntitySystems;
-using Content.Shared._CM14.Webbing;
 using Content.Shared.Explosion;
 using Content.Shared.Inventory;
-using Content.Shared.Inventory.Events;
-using Content.Shared.Storage;
 
 namespace Content.Server.Inventory
 {
     public sealed class ServerInventorySystem : InventorySystem
     {
-        [Dependency] private readonly StorageSystem _storageSystem = default!;
-        [Dependency] private readonly WebbingSystem _webbing = default!;
-
         public override void Initialize()
         {
             base.Initialize();
 
             SubscribeLocalEvent<InventoryComponent, BeforeExplodeEvent>(OnExploded);
-            SubscribeNetworkEvent<OpenSlotStorageNetworkMessage>(OnOpenSlotStorage);
         }
 
         private void OnExploded(Entity<InventoryComponent> ent, ref BeforeExplodeEvent args)
@@ -29,20 +20,6 @@ namespace Content.Server.Inventory
             {
                 if (slot.ContainedEntity != null)
                     args.Contents.Add(slot.ContainedEntity.Value);
-            }
-        }
-
-        private void OnOpenSlotStorage(OpenSlotStorageNetworkMessage ev, EntitySessionEventArgs args)
-        {
-            if (args.SenderSession.AttachedEntity is not { Valid: true } uid)
-                    return;
-
-            if (TryGetSlotEntity(uid, ev.Slot, out var entityUid))
-            {
-                if (TryComp<StorageComponent>(entityUid, out var storageComponent))
-                    _storageSystem.OpenStorageUI(entityUid.Value, uid, storageComponent);
-                else if (TryComp<WebbingClothingComponent>(entityUid, out var webbingClothing))
-                    _webbing.OpenStorage((entityUid.Value, webbingClothing), uid);
             }
         }
 

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -123,8 +123,11 @@ public sealed partial class StorageSystem : SharedStorageSystem
     ///     Opens the storage UI for an entity
     /// </summary>
     /// <param name="entity">The entity to open the UI for</param>
-    public override void OpenStorageUI(EntityUid uid, EntityUid entity, StorageComponent? storageComp = null, bool silent = false)
+    public override void OpenStorageUI(EntityUid uid, EntityUid entity, StorageComponent? storageComp = null, bool silent = false, bool doAfter = true)
     {
+        if (doAfter && CMStorage.OpenDoAfter(uid, entity, storageComp, silent))
+            return;
+
         if (!Resolve(uid, ref storageComp, false) || !TryComp(entity, out ActorComponent? player))
             return;
 

--- a/Content.Server/Storage/EntitySystems/StorageSystem.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.cs
@@ -3,8 +3,6 @@ using Content.Shared.Administration;
 using Content.Shared.Explosion;
 using Content.Shared.Ghost;
 using Content.Shared.Hands;
-using Content.Shared.Input;
-using Content.Shared.Inventory;
 using Content.Shared.Lock;
 using Content.Shared.Storage;
 using Content.Shared.Storage.Components;
@@ -13,7 +11,6 @@ using Content.Shared.Timing;
 using Content.Shared.Verbs;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Input.Binding;
 using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -25,7 +22,6 @@ public sealed partial class StorageSystem : SharedStorageSystem
 {
     [Dependency] private readonly IAdminManager _admin = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
-    [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly UseDelaySystem _useDelay = default!;
@@ -41,11 +37,6 @@ public sealed partial class StorageSystem : SharedStorageSystem
         SubscribeLocalEvent<StorageComponent, BeforeExplodeEvent>(OnExploded);
 
         SubscribeLocalEvent<StorageFillComponent, MapInitEvent>(OnStorageFillMapInit);
-
-        CommandBinds.Builder
-            .Bind(ContentKeyFunctions.OpenBackpack, InputCmdHandler.FromDelegate(HandleOpenBackpack))
-            .Bind(ContentKeyFunctions.OpenBelt, InputCmdHandler.FromDelegate(HandleOpenBelt))
-            .Register<StorageSystem>();
     }
 
     private void AddUiVerb(EntityUid uid, StorageComponent component, GetVerbsEvent<ActivationVerb> args)
@@ -182,32 +173,5 @@ public sealed partial class StorageSystem : SharedStorageSystem
                 _uiSystem.TryClose(entity, bui.UiKey, session, ui);
             }
         }
-    }
-
-    private void HandleOpenBackpack(ICommonSession? session)
-    {
-        HandleOpenSlotUI(session, "back");
-    }
-
-    private void HandleOpenBelt(ICommonSession? session)
-    {
-        HandleOpenSlotUI(session, "belt");
-    }
-
-    private void HandleOpenSlotUI(ICommonSession? session, string slot)
-    {
-        if (session is not { } playerSession)
-            return;
-
-        if (playerSession.AttachedEntity is not {Valid: true} playerEnt || !Exists(playerEnt))
-            return;
-
-        if (!_inventory.TryGetSlotEntity(playerEnt, slot, out var storageEnt))
-            return;
-
-        if (!ActionBlocker.CanInteract(playerEnt, storageEnt))
-            return;
-
-        OpenStorageUI(storageEnt.Value, playerEnt);
     }
 }

--- a/Content.Shared/Inventory/InventorySystem.Slots.cs
+++ b/Content.Shared/Inventory/InventorySystem.Slots.cs
@@ -1,4 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
+using Content.Shared._CM14.Webbing;
+using Content.Shared.Inventory.Events;
+using Content.Shared.Storage;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
@@ -9,10 +12,12 @@ public partial class InventorySystem : EntitySystem
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IViewVariablesManager _vvm = default!;
+    [Dependency] private readonly SharedWebbingSystem _webbing = default!;
 
     private void InitializeSlots()
     {
         SubscribeLocalEvent<InventoryComponent, ComponentInit>(OnInit);
+        SubscribeAllEvent<OpenSlotStorageNetworkMessage>(OnOpenSlotStorage);
 
         _vvm.GetTypeHandler<InventoryComponent>()
             .AddHandler(HandleViewVariablesSlots, ListViewVariablesSlots);
@@ -37,6 +42,20 @@ public partial class InventorySystem : EntitySystem
             var container = _containerSystem.EnsureContainer<ContainerSlot>(uid, slot.Name);
             container.OccludesLight = false;
             component.Containers[i] = container;
+        }
+    }
+
+    private void OnOpenSlotStorage(OpenSlotStorageNetworkMessage ev, EntitySessionEventArgs args)
+    {
+        if (args.SenderSession.AttachedEntity is not { Valid: true } uid)
+            return;
+
+        if (TryGetSlotEntity(uid, ev.Slot, out var entityUid))
+        {
+            if (TryComp<StorageComponent>(entityUid, out var storageComponent))
+                _storageSystem.OpenStorageUI(entityUid.Value, uid, storageComponent);
+            else if (TryComp<WebbingClothingComponent>(entityUid, out var webbingClothing))
+                _webbing.OpenStorage((entityUid.Value, webbingClothing), uid);
         }
     }
 

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -49,7 +49,7 @@ public abstract class SharedStorageSystem : EntitySystem
     [Dependency] protected readonly SharedTransformSystem TransformSystem = default!;
     [Dependency] private   readonly SharedUserInterfaceSystem _ui = default!;
     [Dependency] protected readonly UseDelaySystem UseDelay = default!;
-    [Dependency] protected readonly CMStorageSystem _cmStorage = default!;
+    [Dependency] protected readonly CMStorageSystem CMStorage = default!;
 
     private EntityQuery<ItemComponent> _itemQuery;
     private EntityQuery<StackComponent> _stackQuery;
@@ -187,7 +187,7 @@ public abstract class SharedStorageSystem : EntitySystem
 
     public virtual void UpdateUI(Entity<StorageComponent?> entity) {}
 
-    public virtual void OpenStorageUI(EntityUid uid, EntityUid entity, StorageComponent? storageComp = null, bool silent = false) { }
+    public virtual void OpenStorageUI(EntityUid uid, EntityUid entity, StorageComponent? storageComp = null, bool silent = false, bool doAfter = true) { }
 
     private void AddTransferVerbs(EntityUid uid, StorageComponent component, GetVerbsEvent<UtilityVerb> args)
     {
@@ -754,7 +754,7 @@ public abstract class SharedStorageSystem : EntitySystem
 
         var maxSize = GetMaxItemSize((uid, storageComp));
         if (ItemSystem.GetSizePrototype(item.Size) > maxSize
-            && !_cmStorage.IgnoreItemSize((uid, storageComp), insertEnt))
+            && !CMStorage.IgnoreItemSize((uid, storageComp), insertEnt))
         {
             reason = "comp-storage-too-big";
             return false;
@@ -762,7 +762,7 @@ public abstract class SharedStorageSystem : EntitySystem
 
         if (TryComp<StorageComponent>(insertEnt, out var insertStorage)
             && GetMaxItemSize((insertEnt, insertStorage)) >= maxSize
-            && !_cmStorage.IgnoreItemSize((uid, storageComp), insertEnt))
+            && !CMStorage.IgnoreItemSize((uid, storageComp), insertEnt))
         {
             reason = "comp-storage-too-big";
             return false;

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -10,7 +10,9 @@ using Content.Shared.DoAfter;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Implants.Components;
+using Content.Shared.Input;
 using Content.Shared.Interaction;
+using Content.Shared.Inventory;
 using Content.Shared.Item;
 using Content.Shared.Lock;
 using Content.Shared.Materials;
@@ -23,7 +25,9 @@ using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
+using Robust.Shared.Input.Binding;
 using Robust.Shared.Map;
+using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Serialization;
@@ -42,6 +46,7 @@ public abstract class SharedStorageSystem : EntitySystem
     [Dependency] private   readonly SharedDoAfterSystem _doAfterSystem = default!;
     [Dependency] protected readonly SharedEntityStorageSystem EntityStorage = default!;
     [Dependency] private   readonly SharedInteractionSystem _interactionSystem = default!;
+    [Dependency] private   readonly InventorySystem _inventory = default!;
     [Dependency] protected readonly SharedItemSystem ItemSystem = default!;
     [Dependency] private   readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private   readonly SharedHandsSystem _sharedHandsSystem = default!;
@@ -102,6 +107,11 @@ public abstract class SharedStorageSystem : EntitySystem
         SubscribeAllEvent<StorageSaveItemLocationEvent>(OnSaveItemLocation);
 
         SubscribeLocalEvent<StorageComponent, GotReclaimedEvent>(OnReclaimed);
+
+        CommandBinds.Builder
+            .Bind(ContentKeyFunctions.OpenBackpack, InputCmdHandler.FromDelegate(HandleOpenBackpack))
+            .Bind(ContentKeyFunctions.OpenBelt, InputCmdHandler.FromDelegate(HandleOpenBelt))
+            .Register<SharedStorageSystem>();
 
         UpdatePrototypeCache();
     }
@@ -1280,6 +1290,33 @@ public abstract class SharedStorageSystem : EntitySystem
             UpdateAppearance(container.Owner);
             UpdateUI(container.Owner);
         }
+    }
+
+    private void HandleOpenBackpack(ICommonSession? session)
+    {
+        HandleOpenSlotUI(session, "back");
+    }
+
+    private void HandleOpenBelt(ICommonSession? session)
+    {
+        HandleOpenSlotUI(session, "belt");
+    }
+
+    private void HandleOpenSlotUI(ICommonSession? session, string slot)
+    {
+        if (session is not { } playerSession)
+            return;
+
+        if (playerSession.AttachedEntity is not { Valid: true } playerEnt || !Exists(playerEnt))
+            return;
+
+        if (!_inventory.TryGetSlotEntity(playerEnt, slot, out var storageEnt))
+            return;
+
+        if (!ActionBlocker.CanInteract(playerEnt, storageEnt))
+            return;
+
+        OpenStorageUI(storageEnt.Value, playerEnt);
     }
 
     /// <summary>

--- a/Content.Shared/_CM14/Storage/CMStorageSystem.cs
+++ b/Content.Shared/_CM14/Storage/CMStorageSystem.cs
@@ -108,6 +108,7 @@ public sealed class CMStorageSystem : EntitySystem
         if (!TryComp(uid, out StorageComponent? storage))
             return;
 
+        args.Handled = true;
         _storage.OpenStorageUI(uid.Value, entity.Value, storage, args.Silent, false);
     }
 

--- a/Content.Shared/_CM14/Storage/CMStorageSystem.cs
+++ b/Content.Shared/_CM14/Storage/CMStorageSystem.cs
@@ -1,18 +1,39 @@
-﻿using Content.Shared.Item;
+﻿using Content.Shared.DoAfter;
+using Content.Shared.Item;
 using Content.Shared.Storage;
 using Content.Shared.Storage.Components;
 using Content.Shared.Storage.EntitySystems;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
+using static Content.Shared.Storage.StorageComponent;
 
 namespace Content.Shared._CM14.Storage;
 
 public sealed class CMStorageSystem : EntitySystem
 {
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedItemSystem _item = default!;
+    [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedStorageSystem _storage = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
+
+    private readonly List<EntityUid> _toRemove = new();
 
     public override void Initialize()
     {
         SubscribeLocalEvent<StorageFillComponent, CMStorageItemFillEvent>(OnStorageFillItem);
+        SubscribeLocalEvent<StorageOpenDoAfterComponent, OpenStorageDoAfterEvent>(OnStorageOpenDoAfter);
+
+        Subs.BuiEvents<StorageCloseOnMoveComponent>(StorageUiKey.Key, sub =>
+        {
+            sub.Event<BoundUIOpenedEvent>(OnCloseOnMoveUIOpened);
+        });
+
+        Subs.BuiEvents<StorageOpenComponent>(StorageUiKey.Key, sub =>
+        {
+            sub.Event<BoundUIClosedEvent>(OnCloseOnMoveUIClosed);
+        });
     }
 
     private void OnStorageFillItem(Entity<StorageFillComponent> storage, ref CMStorageItemFillEvent args)
@@ -53,5 +74,98 @@ public sealed class CMStorageSystem : EntitySystem
     {
         return TryComp(storage, out IgnoreContentsSizeComponent? ignore) &&
                ignore.Items.IsValid(item, EntityManager);
+    }
+
+    public bool OpenDoAfter(EntityUid uid, EntityUid entity, StorageComponent? storageComp = null, bool silent = false)
+    {
+        if (!TryComp(uid, out StorageOpenDoAfterComponent? comp) ||
+            comp.Duration == TimeSpan.Zero)
+        {
+            return false;
+        }
+
+        var ev = new OpenStorageDoAfterEvent(GetNetEntity(uid), GetNetEntity(entity), silent);
+        var doAfter = new DoAfterArgs(EntityManager, entity, comp.Duration, ev, uid)
+        {
+            BreakOnMove = true
+        };
+        _doAfter.TryStartDoAfter(doAfter);
+
+        return true;
+    }
+
+    private void OnStorageOpenDoAfter(Entity<StorageOpenDoAfterComponent> ent, ref OpenStorageDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled)
+            return;
+
+        if (!TryGetEntity(args.Uid, out var uid) ||
+            !TryGetEntity(args.Entity, out var entity))
+        {
+            return;
+        }
+
+        if (!TryComp(uid, out StorageComponent? storage))
+            return;
+
+        _storage.OpenStorageUI(uid.Value, entity.Value, storage, args.Silent, false);
+    }
+
+    private void OnCloseOnMoveUIOpened(Entity<StorageCloseOnMoveComponent> ent, ref BoundUIOpenedEvent args)
+    {
+        if (args.Session.AttachedEntity is not { } player)
+            return;
+
+        var coordinates = GetNetCoordinates(_transform.GetMoverCoordinates(player));
+        EnsureComp<StorageOpenComponent>(ent).OpenedAt[player] = coordinates;
+    }
+
+    private void OnCloseOnMoveUIClosed(Entity<StorageOpenComponent> ent, ref BoundUIClosedEvent args)
+    {
+        if (args.Session.AttachedEntity is not { } player)
+            return;
+
+        ent.Comp.OpenedAt.Remove(player);
+    }
+
+    public override void Update(float frameTime)
+    {
+        var query = EntityQueryEnumerator<StorageOpenComponent>();
+        while (query.MoveNext(out var uid, out var open))
+        {
+            _toRemove.Clear();
+            foreach (var (user, netOrigin) in open.OpenedAt)
+            {
+                if (TerminatingOrDeleted(user))
+                {
+                    _toRemove.Add(user);
+                    continue;
+                }
+
+                var origin = GetCoordinates(netOrigin);
+                var current = _transform.GetMoverCoordinates(user);
+
+                if (!origin.InRange(EntityManager, _transform, current, 0.1f))
+                    _toRemove.Add(user);
+            }
+
+            foreach (var user in _toRemove)
+            {
+                if (_net.IsServer && TryComp(user, out ActorComponent? actor))
+                    _ui.TryClose(uid, StorageUiKey.Key, actor.PlayerSession);
+
+                if (_net.IsClient &&
+                    TryComp(uid, out UserInterfaceComponent? ui) &&
+                    ui.OpenInterfaces.TryGetValue(StorageUiKey.Key, out var openUI))
+                {
+                    openUI.Close();
+                }
+
+                open.OpenedAt.Remove(user);
+            }
+
+            if (open.OpenedAt.Count == 0)
+                RemCompDeferred<StorageOpenComponent>(uid);
+        }
     }
 }

--- a/Content.Shared/_CM14/Storage/OpenStorageDoAfterEvent.cs
+++ b/Content.Shared/_CM14/Storage/OpenStorageDoAfterEvent.cs
@@ -1,0 +1,24 @@
+﻿using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._CM14.Storage;
+
+[Serializable, NetSerializable]
+public sealed partial class OpenStorageDoAfterEvent : DoAfterEvent
+{
+    public readonly NetEntity Uid;
+    public readonly NetEntity Entity;
+    public readonly bool Silent;
+
+    public OpenStorageDoAfterEvent(NetEntity uid, NetEntity entity, bool silent)
+    {
+        Uid = uid;
+        Entity = entity;
+        Silent = silent;
+    }
+
+    public override DoAfterEvent Clone()
+    {
+        return new OpenStorageDoAfterEvent(Uid, Entity, Silent);
+    }
+}

--- a/Content.Shared/_CM14/Storage/StorageCloseOnMoveComponent.cs
+++ b/Content.Shared/_CM14/Storage/StorageCloseOnMoveComponent.cs
@@ -1,0 +1,6 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._CM14.Storage;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class StorageCloseOnMoveComponent : Component;

--- a/Content.Shared/_CM14/Storage/StorageOpenComponent.cs
+++ b/Content.Shared/_CM14/Storage/StorageOpenComponent.cs
@@ -1,0 +1,11 @@
+﻿using Robust.Shared.GameStates;
+using Robust.Shared.Map;
+
+namespace Content.Shared._CM14.Storage;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class StorageOpenComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public Dictionary<EntityUid, NetCoordinates> OpenedAt = new();
+}

--- a/Content.Shared/_CM14/Storage/StorageOpenDoAfterComponent.cs
+++ b/Content.Shared/_CM14/Storage/StorageOpenDoAfterComponent.cs
@@ -1,0 +1,10 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._CM14.Storage;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class StorageOpenDoAfterComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public TimeSpan Duration = TimeSpan.FromSeconds(2);
+}

--- a/Resources/Prototypes/_CM14/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_CM14/Entities/Clothing/Back/backpacks.yml
@@ -1,7 +1,8 @@
 # Almayer personnel
 - type: entity
   parent: ClothingBackpack
-  id: CMBackpack
+  abstract: true
+  id: CMPersonalStorageBase
   name: backpack
   description: You wear this on your back and put items into it.
   components:
@@ -22,7 +23,7 @@
           Closed: { visible: false }
         closedLayer:
           Open: { visible: false }
-          Closed: { visible: true}
+          Closed: { visible: true }
   - type: Clothing
     quickEquip: false
     slots:
@@ -37,7 +38,7 @@
       tags:
       - Pouch
       - CMFirstAidKit
-#      - EngineerKit
+  #      - EngineerKit
   - type: ContainerContainer
     containers:
       storagebase: !type:Container
@@ -46,6 +47,15 @@
     interfaces:
     - key: enum.StorageUiKey.Key
       type: StorageBoundUserInterface
+
+- type: entity
+  parent: CMPersonalStorageBase
+  id: CMBackpack
+  name: backpack
+  description: You wear this on your back and put items into it.
+  components:
+  - type: StorageOpenDoAfter
+  - type: StorageCloseOnMove
 
 - type: entity
   parent: CMBackpack

--- a/Resources/Prototypes/_CM14/Entities/Clothing/Back/satchels.yml
+++ b/Resources/Prototypes/_CM14/Entities/Clothing/Back/satchels.yml
@@ -1,6 +1,6 @@
 # Almayer personnel
 - type: entity
-  parent: CMBackpack
+  parent: CMPersonalStorageBase
   id: CMSatchel
   name: leather satchel
   description: A very fancy satchel made of fine leather. Looks pretty pricey.


### PR DESCRIPTION
## About the PR
Resolves #1154 
Includes the changes in https://github.com/space-wizards/space-station-14/pull/27135 so that the do after starting and the auto closing feel smooth for the client.

## Media
https://github.com/CM-14/CM-14/assets/10968691/b392d90e-7a2d-404d-9409-e1b0c445e111

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Backpacks now have a two second delay before opening and will close if the user moves to counterbalance their larger storage. This does not include satchels, pouches or any other kind of storage.