### PR TITLE
Add attaching facehuggers by clicking, huggable component

### DIFF
--- a/Content.Client/_CM14/Xenos/Hugger/XenoHuggerSystem.cs
+++ b/Content.Client/_CM14/Xenos/Hugger/XenoHuggerSystem.cs
@@ -1,10 +1,7 @@
 ﻿using Content.Shared._CM14.Xenos;
-using Content.Shared._CM14.Xenos.Headbutt;
 using Content.Shared._CM14.Xenos.Hugger;
 using Content.Shared.Throwing;
 using Robust.Client.GameObjects;
-using static Robust.Shared.Utility.SpriteSpecifier;
-using XenoLeapComponent = Content.Shared._CM14.Xenos.Leap.XenoLeapComponent;
 
 namespace Content.Client._CM14.Xenos.Hugger;
 

--- a/Content.Shared/_CM14/Xenos/Hugger/AttachHuggerDoAfterEvent.cs
+++ b/Content.Shared/_CM14/Xenos/Hugger/AttachHuggerDoAfterEvent.cs
@@ -1,0 +1,7 @@
+﻿using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._CM14.Xenos.Hugger;
+
+[Serializable, NetSerializable]
+public sealed partial class AttachHuggerDoAfterEvent : SimpleDoAfterEvent;

--- a/Content.Shared/_CM14/Xenos/Hugger/HuggableComponent.cs
+++ b/Content.Shared/_CM14/Xenos/Hugger/HuggableComponent.cs
@@ -1,0 +1,6 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._CM14.Xenos.Hugger;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class HuggableComponent : Component;

--- a/Content.Shared/_CM14/Xenos/Hugger/SharedXenoHuggerSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Hugger/SharedXenoHuggerSystem.cs
@@ -1,5 +1,7 @@
 ﻿using Content.Shared._CM14.Xenos.Leap;
+using Content.Shared.DoAfter;
 using Content.Shared.Eye.Blinding.Systems;
+using Content.Shared.Interaction;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
@@ -17,6 +19,7 @@ public abstract class SharedXenoHuggerSystem : EntitySystem
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly BlindableSystem _blindable = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
@@ -24,7 +27,12 @@ public abstract class SharedXenoHuggerSystem : EntitySystem
 
     public override void Initialize()
     {
+        SubscribeLocalEvent<HuggableComponent, InteractHandEvent>(OnHuggableInteractHand);
+        SubscribeLocalEvent<HuggableComponent, InteractedNoHandEvent>(OnHuggableInteractNoHand);
+
         SubscribeLocalEvent<XenoHuggerComponent, XenoLeapHitEvent>(OnHuggerLeapHit);
+        SubscribeLocalEvent<XenoHuggerComponent, AfterInteractEvent>(OnHuggerAfterInteract);
+        SubscribeLocalEvent<XenoHuggerComponent, AttachHuggerDoAfterEvent>(OnHuggerAttachDoAfter);
 
         SubscribeLocalEvent<HuggerSpentComponent, MapInitEvent>(OnHuggerSpentMapInit);
         SubscribeLocalEvent<HuggerSpentComponent, UpdateMobStateEvent>(OnHuggerSpentUpdateMobState);
@@ -38,25 +46,45 @@ public abstract class SharedXenoHuggerSystem : EntitySystem
         SubscribeLocalEvent<VictimBurstComponent, UpdateMobStateEvent>(OnVictimUpdateMobState);
     }
 
+    private void OnHuggableInteractHand(Entity<HuggableComponent> ent, ref InteractHandEvent args)
+    {
+        if (TryComp(args.User, out XenoHuggerComponent? hugger) &&
+            StartHug((args.User, hugger), args.Target, args.User))
+        {
+            args.Handled = true;
+        }
+    }
+
+    private void OnHuggableInteractNoHand(Entity<HuggableComponent> ent, ref InteractedNoHandEvent args)
+    {
+        if (TryComp(args.User, out XenoHuggerComponent? hugger) &&
+            StartHug((args.User, hugger), args.Target, args.User))
+        {
+            args.Handled = true;
+        }
+    }
+
     private void OnHuggerLeapHit(Entity<XenoHuggerComponent> hugger, ref XenoLeapHitEvent args)
     {
-        if (HasComp<HuggerSpentComponent>(hugger) ||
-            EnsureComp<VictimHuggedComponent>(args.Hit, out var victim))
-        {
+        Hug(hugger, args.Hit);
+    }
+
+    private void OnHuggerAfterInteract(Entity<XenoHuggerComponent> ent, ref AfterInteractEvent args)
+    {
+        if (args.Target == null)
             return;
-        }
 
-        victim.RecoverAt = _timing.CurTime + hugger.Comp.KnockdownTime;
+        if (StartHug(ent, args.Target.Value, ent))
+            args.Handled = true;
+    }
 
-        var container = _container.EnsureContainer<ContainerSlot>(args.Hit, victim.ContainerId);
-        _container.Insert(hugger.Owner, container);
+    private void OnHuggerAttachDoAfter(Entity<XenoHuggerComponent> ent, ref AttachHuggerDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled || args.Target == null)
+            return;
 
-        _blindable.UpdateIsBlind(args.Hit.Owner);
-        _appearance.SetData(hugger, victim.HuggedLayer, true);
-
-        EnsureComp<HuggerSpentComponent>(hugger);
-
-        HuggerLeapHit(hugger);
+        if (Hug(ent, args.Target.Value))
+            args.Handled = true;
     }
 
     protected virtual void HuggerLeapHit(Entity<XenoHuggerComponent> hugger)
@@ -111,6 +139,59 @@ public abstract class SharedXenoHuggerSystem : EntitySystem
     private void OnVictimUpdateMobState(Entity<VictimBurstComponent> burst, ref UpdateMobStateEvent args)
     {
         args.State = MobState.Dead;
+    }
+
+    private bool StartHug(Entity<XenoHuggerComponent> hugger, EntityUid victim, EntityUid user)
+    {
+        if (!CanHug(hugger, victim))
+            return false;
+
+        var ev = new AttachHuggerDoAfterEvent();
+        var doAfter = new DoAfterArgs(EntityManager, user, hugger.Comp.ManualAttachDelay, ev, hugger, victim)
+        {
+            BreakOnMove = true
+        };
+        _doAfter.TryStartDoAfter(doAfter);
+
+        return true;
+    }
+
+    private bool CanHug(Entity<XenoHuggerComponent> hugger, EntityUid victim)
+    {
+        if (!HasComp<HuggableComponent>(victim) ||
+            HasComp<HuggerSpentComponent>(hugger) ||
+            HasComp<VictimHuggedComponent>(victim))
+        {
+            return false;
+        }
+
+        if (TryComp(victim, out StandingStateComponent? standing) &&
+            !_standing.IsDown(victim, standing))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool Hug(Entity<XenoHuggerComponent> hugger, EntityUid victim)
+    {
+        if (!CanHug(hugger, victim))
+            return false;
+
+        var victimComp = EnsureComp<VictimHuggedComponent>(victim);
+        victimComp.RecoverAt = _timing.CurTime + hugger.Comp.KnockdownTime;
+
+        var container = _container.EnsureContainer<ContainerSlot>(victim, victimComp.ContainerId);
+        _container.Insert(hugger.Owner, container);
+
+        _blindable.UpdateIsBlind(victim);
+        _appearance.SetData(hugger, victimComp.HuggedLayer, true);
+
+        EnsureComp<HuggerSpentComponent>(hugger);
+
+        HuggerLeapHit(hugger);
+        return true;
     }
 
     public void RefreshIncubationMultipliers(Entity<VictimHuggedComponent?> ent)

--- a/Content.Shared/_CM14/Xenos/Hugger/XenoHuggerComponent.cs
+++ b/Content.Shared/_CM14/Xenos/Hugger/XenoHuggerComponent.cs
@@ -11,4 +11,7 @@ public sealed partial class XenoHuggerComponent : Component
 
     [DataField, AutoNetworkedField]
     public TimeSpan KnockdownTime = TimeSpan.FromMinutes(1.5);
+
+    [DataField, AutoNetworkedField]
+    public float HugRange = 1.5f;
 }

--- a/Content.Shared/_CM14/Xenos/Hugger/XenoHuggerComponent.cs
+++ b/Content.Shared/_CM14/Xenos/Hugger/XenoHuggerComponent.cs
@@ -7,5 +7,8 @@ namespace Content.Shared._CM14.Xenos.Hugger;
 public sealed partial class XenoHuggerComponent : Component
 {
     [DataField, AutoNetworkedField]
+    public TimeSpan ManualAttachDelay = TimeSpan.FromSeconds(2);
+
+    [DataField, AutoNetworkedField]
     public TimeSpan KnockdownTime = TimeSpan.FromMinutes(1.5);
 }

--- a/Content.Shared/_CM14/Xenos/Leap/XenoLeapHitEvent.cs
+++ b/Content.Shared/_CM14/Xenos/Leap/XenoLeapHitEvent.cs
@@ -3,4 +3,4 @@
 namespace Content.Shared._CM14.Xenos.Leap;
 
 [ByRefEvent]
-public readonly record struct XenoLeapHitEvent(Entity<MarineComponent> Hit);
+public readonly record struct XenoLeapHitEvent(XenoLeapingComponent Leaping, Entity<MarineComponent> Hit);

--- a/Content.Shared/_CM14/Xenos/Leap/XenoLeapingComponent.cs
+++ b/Content.Shared/_CM14/Xenos/Leap/XenoLeapingComponent.cs
@@ -1,5 +1,6 @@
 ﻿using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
+using Robust.Shared.Map;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._CM14.Xenos.Leap;
@@ -7,6 +8,9 @@ namespace Content.Shared._CM14.Xenos.Leap;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class XenoLeapingComponent : Component
 {
+    [DataField, AutoNetworkedField]
+    public EntityCoordinates Origin;
+
     [DataField, AutoNetworkedField]
     public TimeSpan KnockdownTime;
 

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Species/base.yml
@@ -69,3 +69,4 @@
       type: HumanoidMarkingModifierBoundUserInterface
     - key: enum.CMSurgeryUIKey.Key
       type: CMSurgeryBui
+  - type: Huggable

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/hugger.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/hugger.yml
@@ -40,7 +40,7 @@
         - SmallMobLayer
   - type: XenoAnimateMovement
   - type: XenoLeap
-    knockdownTime: 90
+    knockdownTime: 1
   - type: XenoHugger
   - type: Item
   - type: WhitelistPickupBy

--- a/Resources/Prototypes/_CM14/Entities/Mobs/debug_mobs.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/debug_mobs.yml
@@ -1,5 +1,5 @@
 ﻿- type: entity
-  parent: MobHuman
+  parent: CMBaseMobSpeciesOrganic
   id: CMTestDummy
   name: test dummy
   suffix: CM14

--- a/SpaceStation14.sln.DotSettings
+++ b/SpaceStation14.sln.DotSettings
@@ -630,6 +630,7 @@ public sealed partial class $CLASS$ : Shared$CLASS$ {
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hardcode/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hbox/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hotbar/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Huggable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=inhand/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Jitteriness/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Jittering/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
## About the PR
Resolves #1168 
Resolves #1177

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Added attaching facehuggers by clicking downed marines with or as them.
- tweak: Facehuggers can only hug through a leap if it is done within a very short range of the target.
