### PR TITLE
Add tackling

### DIFF
--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Client.Gameplay;
+using Content.Shared._CM14.Tackle;
 using Content.Shared.CombatMode;
 using Content.Shared.Effects;
 using Content.Shared.Hands.Components;
@@ -184,6 +185,13 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         }
 
         var target = GetEntity(ev.Target);
+        if (target != null)
+        {
+            var cmDisarmEvent = new CMDisarmEvent(user);
+            RaiseLocalEvent(target.Value, ref cmDisarmEvent);
+            if (cmDisarmEvent.Handled)
+                return true;
+        }
 
         // They need to either have hands...
         if (!HasComp<HandsComponent>(target!.Value))

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -1,6 +1,9 @@
+using System.Linq;
+using System.Numerics;
 using Content.Server.Chat.Systems;
 using Content.Server.CombatMode.Disarm;
 using Content.Server.Movement.Systems;
+using Content.Shared._CM14.Tackle;
 using Content.Shared.Actions.Events;
 using Content.Shared.Administration.Components;
 using Content.Shared.CombatMode;
@@ -21,8 +24,6 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
-using System.Linq;
-using System.Numerics;
 
 namespace Content.Server.Weapons.Melee;
 
@@ -91,6 +92,10 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
         }
 
         var target = GetEntity(ev.Target!.Value);
+        var cmDisarmEvent = new CMDisarmEvent(user);
+        RaiseLocalEvent(target, ref cmDisarmEvent);
+        if (cmDisarmEvent.Handled)
+            return true;
 
         if (_mobState.IsIncapacitated(target))
         {

--- a/Content.Shared/_CM14/Pulling/ParalyzeOnPullAttemptComponent.cs
+++ b/Content.Shared/_CM14/Pulling/ParalyzeOnPullAttemptComponent.cs
@@ -3,7 +3,7 @@
 namespace Content.Shared._CM14.Pulling;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-public sealed partial class KnockdownOnPullAttemptComponent : Component
+public sealed partial class ParalyzeOnPullAttemptComponent : Component
 {
     [DataField, AutoNetworkedField]
     public TimeSpan Duration = TimeSpan.FromSeconds(8);

--- a/Content.Shared/_CM14/Pulling/ParalyzeOnPullAttemptImmuneComponent.cs
+++ b/Content.Shared/_CM14/Pulling/ParalyzeOnPullAttemptImmuneComponent.cs
@@ -3,4 +3,4 @@
 namespace Content.Shared._CM14.Pulling;
 
 [RegisterComponent, NetworkedComponent]
-public sealed partial class KnockdownOnPullAttemptImmuneComponent : Component;
+public sealed partial class ParalyzeOnPullAttemptImmuneComponent : Component;

--- a/Content.Shared/_CM14/Pulling/ParalyzeOnPullAttemptSystem.cs
+++ b/Content.Shared/_CM14/Pulling/ParalyzeOnPullAttemptSystem.cs
@@ -8,7 +8,7 @@ using Robust.Shared.Timing;
 
 namespace Content.Shared._CM14.Pulling;
 
-public sealed class KnockdownOnPullAttemptSystem : EntitySystem
+public sealed class ParalyzeOnPullAttemptSystem : EntitySystem
 {
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
@@ -17,22 +17,21 @@ public sealed class KnockdownOnPullAttemptSystem : EntitySystem
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<KnockdownOnPullAttemptComponent, PullAttemptEvent>(OnKnockdownOnPullAttempt);
+        SubscribeLocalEvent<ParalyzeOnPullAttemptComponent, PullAttemptEvent>(OnParalyzeOnPullAttempt);
     }
 
-    private void OnKnockdownOnPullAttempt(Entity<KnockdownOnPullAttemptComponent> ent, ref PullAttemptEvent args)
+    private void OnParalyzeOnPullAttempt(Entity<ParalyzeOnPullAttemptComponent> ent, ref PullAttemptEvent args)
     {
         var user = args.PullerUid;
         var target = args.PulledUid;
         if (target != ent.Owner ||
-            HasComp<KnockdownOnPullAttemptImmuneComponent>(user) ||
+            HasComp<ParalyzeOnPullAttemptImmuneComponent>(user) ||
             _mobState.IsIncapacitated(ent))
         {
             return;
         }
 
-        _stun.TryStun(user, ent.Comp.Duration, true);
-        _stun.TryKnockdown(user, ent.Comp.Duration, true);
+        _stun.TryParalyze(user, ent.Comp.Duration, true);
         args.Cancelled = true;
 
         if (!_timing.IsFirstTimePredicted)

--- a/Content.Shared/_CM14/Tackle/CMDisarmEvent.cs
+++ b/Content.Shared/_CM14/Tackle/CMDisarmEvent.cs
@@ -1,0 +1,4 @@
+﻿namespace Content.Shared._CM14.Tackle;
+
+[ByRefEvent]
+public record struct CMDisarmEvent(EntityUid User, bool Handled = false);

--- a/Content.Shared/_CM14/Tackle/TackleComponent.cs
+++ b/Content.Shared/_CM14/Tackle/TackleComponent.cs
@@ -1,0 +1,14 @@
+﻿using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._CM14.Tackle;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class TackleComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 Strength = 1;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan Stun = TimeSpan.FromSeconds(8);
+}

--- a/Content.Shared/_CM14/Tackle/TackleComponent.cs
+++ b/Content.Shared/_CM14/Tackle/TackleComponent.cs
@@ -10,5 +10,14 @@ public sealed partial class TackleComponent : Component
     public FixedPoint2 Strength = 1;
 
     [DataField, AutoNetworkedField]
-    public TimeSpan Stun = TimeSpan.FromSeconds(8);
+    public FixedPoint2 Min = 2;
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 Max = 6;
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 Chance = 0.35;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan Stun = TimeSpan.FromSeconds(5);
 }

--- a/Content.Shared/_CM14/Tackle/TackleComponent.cs
+++ b/Content.Shared/_CM14/Tackle/TackleComponent.cs
@@ -10,13 +10,7 @@ public sealed partial class TackleComponent : Component
     public FixedPoint2 Strength = 1;
 
     [DataField, AutoNetworkedField]
-    public FixedPoint2 Min = 2;
-
-    [DataField, AutoNetworkedField]
-    public FixedPoint2 Max = 6;
-
-    [DataField, AutoNetworkedField]
-    public FixedPoint2 Chance = 0.35;
+    public FixedPoint2 Threshold = 4;
 
     [DataField, AutoNetworkedField]
     public TimeSpan Stun = TimeSpan.FromSeconds(5);

--- a/Content.Shared/_CM14/Tackle/TackleSystem.cs
+++ b/Content.Shared/_CM14/Tackle/TackleSystem.cs
@@ -1,0 +1,106 @@
+﻿using Content.Shared.CombatMode;
+using Content.Shared.Damage.Systems;
+using Content.Shared.Effects;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Popups;
+using Content.Shared.Stunnable;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._CM14.Tackle;
+
+public sealed class TackleSystem : EntitySystem
+{
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedColorFlashEffectSystem _colorFlash = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedStunSystem _stun = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<TackleableComponent, CMDisarmEvent>(OnDisarmed, before: [typeof(SharedHandsSystem), typeof(StaminaSystem)]);
+    }
+
+    private void OnDisarmed(Entity<TackleableComponent> target, ref CMDisarmEvent args)
+    {
+        if (!TryComp(args.User, out TackleComponent? tackle))
+            return;
+
+        args.Handled = true;
+
+        var time = _timing.CurTime;
+        var recently = EnsureComp<TackledRecentlyComponent>(target);
+        recently.LastTackled = time;
+        recently.Current += tackle.Strength;
+
+        Dirty(target, recently);
+
+        _colorFlash.RaiseEffect(Color.Aqua, new List<EntityUid> { target.Owner }, Filter.PvsExcept(args.User));
+
+        if (recently.Current < target.Comp.Threshold)
+        {
+            var targetName = Identity.Name(target, EntityManager, args.User);
+            _popup.PopupClient($"You try to tackle {targetName}", args.User, args.User);
+
+            foreach (var session in Filter.PvsExcept(args.User).Recipients)
+            {
+                if (session.AttachedEntity is not { } recipient)
+                    continue;
+
+                var userName = Identity.Name(args.User, EntityManager, recipient);
+                targetName = Identity.Name(target, EntityManager, recipient);
+
+                if (recipient == target.Owner)
+                    _popup.PopupEntity($"{userName} tries to tackle you", args.User, recipient, PopupType.MediumCaution);
+                else
+                    _popup.PopupEntity($"{userName} tries to tackle {targetName}", args.User, recipient);
+            }
+
+            return;
+        }
+        else
+        {
+            var targetName = Identity.Name(target, EntityManager, args.User);
+            _popup.PopupClient($"You tackle down {targetName}!", args.User, args.User);
+
+            foreach (var session in Filter.PvsExcept(args.User).Recipients)
+            {
+                if (session.AttachedEntity is not { } recipient)
+                    continue;
+
+                var userName = Identity.Name(args.User, EntityManager, recipient);
+                targetName = Identity.Name(target, EntityManager, recipient);
+
+                if (recipient == target.Owner)
+                    _popup.PopupEntity($"{userName} tackled you down!", args.User, recipient, PopupType.MediumCaution);
+                else
+                    _popup.PopupEntity($"{userName} tackles down {targetName}!", args.User, recipient);
+            }
+        }
+
+        if (TryComp(args.User, out CombatModeComponent? combatMode))
+        {
+            var audioParams = AudioParams.Default.WithVariation(0.025f).WithVolume(5f);
+            _audio.PlayPredicted(combatMode.DisarmSuccessSound, target, args.User, audioParams);
+        }
+
+        _stun.TryParalyze(target, tackle.Stun, true);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var time = _timing.CurTime;
+        var query = EntityQueryEnumerator<TackledRecentlyComponent, TackleableComponent>();
+        while (query.MoveNext(out var uid, out var recently, out var able))
+        {
+            if (time > recently.LastTackled + able.Expires)
+                RemCompDeferred<TackledRecentlyComponent>(uid);
+        }
+    }
+}

--- a/Content.Shared/_CM14/Tackle/TackleableComponent.cs
+++ b/Content.Shared/_CM14/Tackle/TackleableComponent.cs
@@ -1,14 +1,10 @@
-﻿using Content.Shared.FixedPoint;
-using Robust.Shared.GameStates;
+﻿using Robust.Shared.GameStates;
 
 namespace Content.Shared._CM14.Tackle;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class TackleableComponent : Component
 {
-    [DataField, AutoNetworkedField]
-    public FixedPoint2 Threshold = 5;
-
     [DataField, AutoNetworkedField]
     public TimeSpan Expires = TimeSpan.FromSeconds(4);
 }

--- a/Content.Shared/_CM14/Tackle/TackleableComponent.cs
+++ b/Content.Shared/_CM14/Tackle/TackleableComponent.cs
@@ -1,0 +1,14 @@
+﻿using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._CM14.Tackle;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class TackleableComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 Threshold = 5;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan Expires = TimeSpan.FromSeconds(4);
+}

--- a/Content.Shared/_CM14/Tackle/TackledRecentlyComponent.cs
+++ b/Content.Shared/_CM14/Tackle/TackledRecentlyComponent.cs
@@ -1,0 +1,14 @@
+﻿using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._CM14.Tackle;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class TackledRecentlyComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 Current;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan LastTackled;
+}

--- a/Content.Shared/_CM14/Xenos/Hugger/SharedXenoHuggerSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Hugger/SharedXenoHuggerSystem.cs
@@ -185,9 +185,8 @@ public abstract class SharedXenoHuggerSystem : EntitySystem
             return false;
 
         var victimComp = EnsureComp<VictimHuggedComponent>(victim);
-        victimComp.RecoverAt = _timing.CurTime + hugger.Comp.KnockdownTime;
-        _stun.TryKnockdown(victim, hugger.Comp.KnockdownTime, true);
-        _stun.TryStun(victim, hugger.Comp.KnockdownTime, true);
+        victimComp.RecoverAt = _timing.CurTime + hugger.Comp.ParalyzeTime;
+        _stun.TryParalyze(victim, hugger.Comp.ParalyzeTime, true);
 
         var container = _container.EnsureContainer<ContainerSlot>(victim, victimComp.ContainerId);
         _container.Insert(hugger.Owner, container);

--- a/Content.Shared/_CM14/Xenos/Hugger/XenoHuggerComponent.cs
+++ b/Content.Shared/_CM14/Xenos/Hugger/XenoHuggerComponent.cs
@@ -10,7 +10,7 @@ public sealed partial class XenoHuggerComponent : Component
     public TimeSpan ManualAttachDelay = TimeSpan.FromSeconds(2);
 
     [DataField, AutoNetworkedField]
-    public TimeSpan KnockdownTime = TimeSpan.FromMinutes(1.5);
+    public TimeSpan ParalyzeTime = TimeSpan.FromMinutes(1.5);
 
     [DataField, AutoNetworkedField]
     public float HugRange = 1.5f;

--- a/Content.Shared/_CM14/Xenos/Leap/SharedXenoLeapSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Leap/SharedXenoLeapSystem.cs
@@ -104,7 +104,7 @@ public sealed class SharedXenoLeapSystem : EntitySystem
         var impulse = direction.Normalized() * xeno.Comp.Strength * physics.Mass;
 
         leaping.Origin = _transform.GetMoverCoordinates(xeno);
-        leaping.KnockdownTime = xeno.Comp.KnockdownTime;
+        leaping.ParalyzeTime = xeno.Comp.KnockdownTime;
         leaping.HitSound = xeno.Comp.HitSound;
         leaping.LeapEndTime = _timing.CurTime + TimeSpan.FromSeconds(direction.Length() / xeno.Comp.Strength);
 
@@ -130,11 +130,9 @@ public sealed class SharedXenoLeapSystem : EntitySystem
                 _broadphase.RegenerateContacts(xeno, physics);
         }
 
-        victim.RecoverAt = _timing.CurTime + xeno.Comp.KnockdownTime;
+        victim.RecoverAt = _timing.CurTime + xeno.Comp.ParalyzeTime;
 
-        _stun.TryKnockdown(marineId, xeno.Comp.KnockdownTime, true);
-        _stun.TryStun(marineId, xeno.Comp.KnockdownTime, true);
-
+        _stun.TryParalyze(marineId, xeno.Comp.ParalyzeTime, true);
         _audio.PlayPredicted(xeno.Comp.HitSound, xeno, xeno);
 
         var ev = new XenoLeapHitEvent(xeno, (marineId, marine));

--- a/Content.Shared/_CM14/Xenos/Leap/XenoLeapingComponent.cs
+++ b/Content.Shared/_CM14/Xenos/Leap/XenoLeapingComponent.cs
@@ -12,7 +12,7 @@ public sealed partial class XenoLeapingComponent : Component
     public EntityCoordinates Origin;
 
     [DataField, AutoNetworkedField]
-    public TimeSpan KnockdownTime;
+    public TimeSpan ParalyzeTime;
 
     [DataField, AutoNetworkedField]
     public SoundSpecifier? HitSound;

--- a/Content.Shared/_CM14/Xenos/Paralyzing/XenoActiveParalyzingSlashComponent.cs
+++ b/Content.Shared/_CM14/Xenos/Paralyzing/XenoActiveParalyzingSlashComponent.cs
@@ -10,8 +10,8 @@ public sealed partial class XenoActiveParalyzingSlashComponent : Component
     public TimeSpan ExpireAt;
 
     [DataField, AutoNetworkedField]
-    public TimeSpan StunDelay = TimeSpan.FromSeconds(4);
+    public TimeSpan ParalyzeDelay = TimeSpan.FromSeconds(4);
 
     [DataField, AutoNetworkedField]
-    public TimeSpan StunDuration = TimeSpan.FromSeconds(4);
+    public TimeSpan ParalyzeDuration = TimeSpan.FromSeconds(4);
 }

--- a/Content.Shared/_CM14/Xenos/Paralyzing/XenoParalyzingSlashSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Paralyzing/XenoParalyzingSlashSystem.cs
@@ -41,8 +41,8 @@ public sealed class XenoParalyzingSlashSystem : EntitySystem
         var active = EnsureComp<XenoActiveParalyzingSlashComponent>(xeno);
 
         active.ExpireAt = _timing.CurTime + xeno.Comp.ActiveDuration;
-        active.StunDelay = xeno.Comp.StunDelay;
-        active.StunDuration = xeno.Comp.StunDuration;
+        active.ParalyzeDelay = xeno.Comp.StunDelay;
+        active.ParalyzeDuration = xeno.Comp.StunDuration;
 
         Dirty(xeno, active);
 
@@ -65,8 +65,8 @@ public sealed class XenoParalyzingSlashSystem : EntitySystem
             // TODO CM14 slight blindness
             var victim = EnsureComp<VictimBeingParalyzedComponent>(entity);
 
-            victim.ParalyzeAt = _timing.CurTime + xeno.Comp.StunDelay;
-            victim.ParalyzeDuration = xeno.Comp.StunDuration;
+            victim.ParalyzeAt = _timing.CurTime + xeno.Comp.ParalyzeDelay;
+            victim.ParalyzeDuration = xeno.Comp.ParalyzeDuration;
 
             Dirty(entity, victim);
 
@@ -108,8 +108,7 @@ public sealed class XenoParalyzingSlashSystem : EntitySystem
                 continue;
 
             RemCompDeferred<VictimBeingParalyzedComponent>(uid);
-            _stun.TryKnockdown(uid, victim.ParalyzeDuration, true);
-            _stun.TryStun(uid, victim.ParalyzeDuration, true);
+            _stun.TryParalyze(uid, victim.ParalyzeDuration, true);
         }
     }
 }

--- a/Content.Shared/_CM14/Xenos/Projectile/Spit/Slowing/XenoSlowingSpitProjectileComponent.cs
+++ b/Content.Shared/_CM14/Xenos/Projectile/Spit/Slowing/XenoSlowingSpitProjectileComponent.cs
@@ -10,7 +10,7 @@ public sealed partial class XenoSlowingSpitProjectileComponent : Component
     public TimeSpan Slow = TimeSpan.FromSeconds(3);
 
     [DataField, AutoNetworkedField]
-    public TimeSpan Knockdown = TimeSpan.FromSeconds(2);
+    public TimeSpan Paralyze = TimeSpan.FromSeconds(2);
 
     [DataField, AutoNetworkedField]
     public bool ArmorResistsKnockdown = true;

--- a/Content.Shared/_CM14/Xenos/Projectile/Spit/XenoSpitSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Projectile/Spit/XenoSpitSystem.cs
@@ -101,10 +101,7 @@ public sealed class XenoSpitSystem : EntitySystem
         }
 
         if (!resisted)
-        {
-            _stun.TryKnockdown(target, spit.Comp.Knockdown, true);
-            _stun.TryStun(target, spit.Comp.Knockdown, true);
-        }
+            _stun.TryParalyze(target, spit.Comp.Paralyze, true);
 
         _colorFlash.RaiseEffect(Color.Red, new List<EntityUid> { target }, Filter.Pvs(target));
     }

--- a/Content.Shared/_CM14/Xenos/Sweep/XenoTailSweepComponent.cs
+++ b/Content.Shared/_CM14/Xenos/Sweep/XenoTailSweepComponent.cs
@@ -21,7 +21,7 @@ public sealed partial class XenoTailSweepComponent : Component
 
     // TODO CM14 scale with damage dealt up to a cap
     [DataField, AutoNetworkedField]
-    public TimeSpan StunTime = TimeSpan.FromSeconds(2);
+    public TimeSpan ParalyzeTime = TimeSpan.FromSeconds(2);
 
     [DataField, AutoNetworkedField]
     public SoundSpecifier Sound = new SoundCollectionSpecifier("XenoTailSwipe");

--- a/Content.Shared/_CM14/Xenos/Sweep/XenoTailSweepSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Sweep/XenoTailSweepSystem.cs
@@ -74,8 +74,7 @@ public sealed class XenoTailSweepSystem : EntitySystem
             _colorFlash.RaiseEffect(Color.Red, new List<EntityUid> { marine }, filter);
 
             _throwing.TryThrow(marine, diff, 5);
-            _stun.TryKnockdown(marine, xeno.Comp.StunTime, true);
-            _stun.TryStun(marine, xeno.Comp.StunTime, true);
+            _stun.TryParalyze(marine, xeno.Comp.ParalyzeTime, true);
 
             _audio.PlayPvs(xeno.Comp.HitSound, marine);
             SpawnAttachedTo(xeno.Comp.HitEffect, marine.Owner.ToCoordinates());

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -92,7 +92,7 @@
   - type: InventorySlots
   - type: Loadout
     prototypes: [ MobAghostGear ]
-  - type: KnockdownOnPullAttemptImmune
+  - type: ParalyzeOnPullAttemptImmune
 
 - type: entity
   id: ActionAGhostShowSolar

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Species/base.yml
@@ -70,3 +70,7 @@
     - key: enum.CMSurgeryUIKey.Key
       type: CMSurgeryBui
   - type: Huggable
+  - type: Tackleable
+  - type: Tackle
+    stun: 10
+

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/base_xeno.yml
@@ -224,6 +224,8 @@
   id: CMXenoMelee
   components:
   - type: CombatMode
+    canDisarm: true
+    disarmFailChance: 0
   - type: MeleeWeapon
     widePrimary: true
     altDisarm: true
@@ -234,6 +236,7 @@
     damage:
       groups:
         Brute: 12
+  - type: Tackle
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/base_xeno.yml
@@ -186,7 +186,7 @@
     - type: XenoEgg
   - type: DropHeldOnIncapacitate
   - type: NightVision
-  - type: KnockdownOnPullAttemptImmune
+  - type: ParalyzeOnPullAttemptImmune
   - type: GhostTakeoverAvailable
   - type: GhostRole
     makeSentient: true
@@ -286,7 +286,7 @@
       location: Right
     - name: Left Hand
       location: Left
-  - type: KnockdownOnPullAttempt
+  - type: ParalyzeOnPullAttempt
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/boiler.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/boiler.yml
@@ -45,7 +45,5 @@
       groups:
         Brute: 22.5
   - type: Tackle
-    min: 2
-    max: 6
-    chance: 0.25
+    threshold: 5
     stun: 7

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/boiler.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/boiler.yml
@@ -44,3 +44,8 @@
     damage:
       groups:
         Brute: 22.5
+  - type: Tackle
+    min: 2
+    max: 6
+    chance: 0.25
+    stun: 7

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/burrower.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/burrower.yml
@@ -45,7 +45,5 @@
       groups:
         Brute: 27.5
   - type: Tackle
-    min: 3
-    max: 5
-    chance: 0.40
+    threshold: 4
     stun: 9

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/burrower.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/burrower.yml
@@ -44,3 +44,8 @@
     damage:
       groups:
         Brute: 27.5
+  - type: Tackle
+    min: 3
+    max: 5
+    chance: 0.40
+    stun: 9

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/carrier.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/carrier.yml
@@ -48,3 +48,8 @@
     damage:
       groups:
         Brute: 27.5
+  - type: Tackle
+    min: 2
+    max: 4
+    chance: 0.50
+    stun: 9

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/carrier.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/carrier.yml
@@ -49,7 +49,5 @@
       groups:
         Brute: 27.5
   - type: Tackle
-    min: 2
-    max: 4
-    chance: 0.50
+    threshold: 3
     stun: 9

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/crusher.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/crusher.yml
@@ -40,3 +40,8 @@
     damage:
       groups:
         Brute: 40
+  - type: Tackle
+    min: 2
+    max: 6
+    chance: 0.25
+    stun: 5

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/crusher.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/crusher.yml
@@ -41,7 +41,5 @@
       groups:
         Brute: 40
   - type: Tackle
-    min: 2
-    max: 6
-    chance: 0.25
+    threshold: 5
     stun: 5

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/defender.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/defender.yml
@@ -56,3 +56,8 @@
     damage:
       groups:
         Brute: 27.5
+  - type: Tackle
+    min: 2
+    max: 4
+    chance: 0.35
+    stun: 5

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/defender.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/defender.yml
@@ -57,7 +57,5 @@
       groups:
         Brute: 27.5
   - type: Tackle
-    min: 2
-    max: 4
-    chance: 0.35
+    threshold: 4
     stun: 5

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/drone.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/drone.yml
@@ -54,3 +54,8 @@
     plasma: 1000
     maxPlasma: 1000
     plasmaRegenOnWeeds: 6
+  - type: Tackle
+    min: 2
+    max: 4
+    chance: 0.35
+    stun: 7

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/drone.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/drone.yml
@@ -55,7 +55,5 @@
     maxPlasma: 1000
     plasmaRegenOnWeeds: 6
   - type: Tackle
-    min: 2
-    max: 4
-    chance: 0.35
+    threshold: 4
     stun: 7

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/hivelord.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/hivelord.yml
@@ -57,7 +57,5 @@
       groups:
         Brute: 22.5
   - type: Tackle
-    min: 2
-    max: 4
-    chance: 0.45
+    min: 3
     stun: 9

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/hivelord.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/hivelord.yml
@@ -56,3 +56,8 @@
     damage:
       groups:
         Brute: 22.5
+  - type: Tackle
+    min: 2
+    max: 4
+    chance: 0.45
+    stun: 9

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/hivelord.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/hivelord.yml
@@ -57,5 +57,5 @@
       groups:
         Brute: 22.5
   - type: Tackle
-    min: 3
+    threshold: 3
     stun: 9

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/lesser_drone.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/lesser_drone.yml
@@ -47,7 +47,5 @@
       groups:
         Brute: 20
   - type: Tackle
-    min: 4
-    max: 5
-    chance: 0.35
+    threshold: 5
     stun: 5

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/lesser_drone.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/lesser_drone.yml
@@ -46,3 +46,8 @@
     damage:
       groups:
         Brute: 20
+  - type: Tackle
+    min: 4
+    max: 5
+    chance: 0.35
+    stun: 5

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/lurker.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/lurker.yml
@@ -44,3 +44,8 @@
     damage:
       groups:
         Brute: 35
+  - type: Tackle
+    min: 2
+    max: 6
+    chance: 0.35
+    stun: 5

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/lurker.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/lurker.yml
@@ -45,7 +45,5 @@
       groups:
         Brute: 35
   - type: Tackle
-    min: 2
-    max: 6
-    chance: 0.35
+    threshold: 4
     stun: 5

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/praetorian.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/praetorian.yml
@@ -43,3 +43,8 @@
     damage:
       groups:
         Brute: 40
+  - type: Tackle
+    min: 2
+    max: 5
+    chance: 0.45
+    stun: 5

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/praetorian.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/praetorian.yml
@@ -44,7 +44,5 @@
       groups:
         Brute: 40
   - type: Tackle
-    min: 2
-    max: 5
-    chance: 0.45
+    threshold: 3
     stun: 5

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/queen.yml
@@ -75,7 +75,5 @@
         Brute: 40
   - type: XenoOvipositorCapable
   - type: Tackle
-    min: 2
-    max: 6
-    chance: 0.55
+    threshold: 3
     stun: 11

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/queen.yml
@@ -74,3 +74,8 @@
       groups:
         Brute: 40
   - type: XenoOvipositorCapable
+  - type: Tackle
+    min: 2
+    max: 6
+    chance: 0.55
+    stun: 11

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/ravager.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/ravager.yml
@@ -41,7 +41,5 @@
       groups:
         Brute: 45
   - type: Tackle
-    min: 2
-    max: 5
-    chance: 0.35
+    threshold: 4
     stun: 9

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/ravager.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/ravager.yml
@@ -40,3 +40,8 @@
     damage:
       groups:
         Brute: 45
+  - type: Tackle
+    min: 2
+    max: 5
+    chance: 0.35
+    stun: 9

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/runner.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/runner.yml
@@ -51,3 +51,8 @@
     damage:
       groups:
         Brute: 22.5
+  - type: Tackle
+    min: 4
+    max: 5
+    chance: 0.40
+    stun: 8

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/runner.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/runner.yml
@@ -52,7 +52,5 @@
       groups:
         Brute: 22.5
   - type: Tackle
-    min: 4
-    max: 5
-    chance: 0.40
+    threshold: 5
     stun: 8

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/sentinel.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/sentinel.yml
@@ -47,7 +47,5 @@
       groups:
         Brute: 22.5
   - type: Tackle
-    min: 4
-    max: 4
-    chance: 0.50
+    threshold: 4
     stun: 8

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/sentinel.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/sentinel.yml
@@ -46,3 +46,8 @@
     damage:
       groups:
         Brute: 22.5
+  - type: Tackle
+    min: 4
+    max: 4
+    chance: 0.50
+    stun: 8

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/spitter.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/spitter.yml
@@ -47,3 +47,8 @@
     damage:
       groups:
         Brute: 25
+  - type: Tackle
+    min: 2
+    max: 6
+    chance: 0.45
+    stun: 9

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/spitter.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/spitter.yml
@@ -48,7 +48,5 @@
       groups:
         Brute: 25
   - type: Tackle
-    min: 2
-    max: 6
-    chance: 0.45
+    threshold: 4
     stun: 9

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/warrior.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/warrior.yml
@@ -47,7 +47,5 @@
       groups:
         Brute: 35
   - type: Tackle
-    min: 2
-    max: 4
-    chance: 0.35
+    threshold: 4
     stun: 5

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/warrior.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/warrior.yml
@@ -46,3 +46,8 @@
     damage:
       groups:
         Brute: 35
+  - type: Tackle
+    min: 2
+    max: 4
+    chance: 0.35
+    stun: 5

--- a/Resources/Prototypes/_CM14/Entities/Objects/Xeno/xeno_projectiles.yml
+++ b/Resources/Prototypes/_CM14/Entities/Objects/Xeno/xeno_projectiles.yml
@@ -56,7 +56,7 @@
       shader: unshaded
   - type: XenoSlowingSpitProjectile
     slow: 0
-    knockdown: 1
+    paralyze: 1
     armorResistsKnockdown: false
 
 - type: entity
@@ -73,7 +73,7 @@
       shader: unshaded
   - type: XenoSlowingSpitProjectile
     slow: 5
-    knockdown: 0
+    paralyze: 0
   - type: TimedDespawn
     lifetime: 0.2
   - type: Projectile

--- a/SpaceStation14.sln.DotSettings
+++ b/SpaceStation14.sln.DotSettings
@@ -696,6 +696,7 @@ public sealed partial class $CLASS$ : Shared$CLASS$ {
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Superconduct/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=superconduction/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/UserDictionary/Words/=swsl/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tackleable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=TCMB/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Teleporter/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Thermite/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
## About the PR
Resolves #1268 
No rng unlike regular disarms.
Default is 4 disarms with less than 4 seconds between each and the next results in a knockdown and a stun of 5 seconds.
Varies per xeno caste.
Continuing to disarm a tackled-down marine will start applying stacks again, so if the xeno keeps disarming in less than 4 seconds interval it will be able to keep the marine downed.

## Media
https://github.com/CM-14/CM-14/assets/10968691/d881ff75-0031-4644-a229-3725db984467

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Added tackling on disarm. Successfully disarming a marine 4 times in a row with less than 4 seconds passing between each disarm will result in them getting knocked down and stunned for 5 seconds. The disarms needed and stun duration vary per xeno caste.