### PR TITLE
Make the ravager and queen immune to catching fire, add resisting fire to xenos

### DIFF
--- a/Content.Client/_CM14/Xenos/XenoVisualizerSystem.cs
+++ b/Content.Client/_CM14/Xenos/XenoVisualizerSystem.cs
@@ -8,6 +8,8 @@ using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
+using Content.Shared.StatusEffect;
+using Content.Shared.Stunnable;
 using Content.Shared.Throwing;
 using Robust.Client.GameObjects;
 using DrawDepth = Content.Shared.DrawDepth.DrawDepth;
@@ -18,11 +20,27 @@ public sealed class XenoVisualizerSystem : VisualizerSystem<XenoComponent>
 {
     [Dependency] private readonly MobStateSystem _mobState = default!;
 
+    private EntityQuery<XenoAnimateMovementComponent> _animateQuery;
+
     public override void Initialize()
     {
         base.Initialize();
 
+        SubscribeLocalEvent<XenoComponent, KnockedDownEvent>(OnXenoKnockedDown);
+        SubscribeLocalEvent<XenoComponent, StatusEffectEndedEvent>(OnXenoStatusEffectEnded);
         SubscribeLocalEvent<XenoComponent, GetDrawDepthEvent>(OnXenoGetDrawDepth);
+
+        _animateQuery = GetEntityQuery<XenoAnimateMovementComponent>();
+    }
+
+    private void OnXenoKnockedDown(Entity<XenoComponent> xeno, ref KnockedDownEvent args)
+    {
+        UpdateSprite(xeno.Owner);
+    }
+
+    private void OnXenoStatusEffectEnded(Entity<XenoComponent> xeno, ref StatusEffectEndedEvent args)
+    {
+        UpdateSprite(xeno.Owner);
     }
 
     private void OnXenoGetDrawDepth(Entity<XenoComponent> ent, ref GetDrawDepthEvent args)
@@ -43,9 +61,9 @@ public sealed class XenoVisualizerSystem : VisualizerSystem<XenoComponent>
         UpdateDrawDepth((uid, sprite));
     }
 
-    public void UpdateSprite(Entity<SpriteComponent?, MobStateComponent?, AppearanceComponent?, InputMoverComponent?, ThrownItemComponent?, XenoLeapingComponent?> entity)
+    public void UpdateSprite(Entity<SpriteComponent?, MobStateComponent?, AppearanceComponent?, InputMoverComponent?, ThrownItemComponent?, XenoLeapingComponent?, KnockedDownComponent?> entity)
     {
-        var (_, sprite, mobState, appearance, input, thrown, leaping) = entity;
+        var (_, sprite, mobState, appearance, input, thrown, leaping, knocked) = entity;
         if (!Resolve(entity, ref sprite, ref appearance))
             return;
 
@@ -53,7 +71,9 @@ public sealed class XenoVisualizerSystem : VisualizerSystem<XenoComponent>
         if (Resolve(entity, ref mobState, false))
             state = mobState.CurrentState;
 
-        Resolve(entity, ref input, ref thrown, ref leaping, false);
+        Resolve(entity, ref input, ref thrown, ref leaping, ref knocked, false);
+        if (knocked != null)
+            state = MobState.Critical;
 
         if (sprite is not { BaseRSI: { } rsi } ||
             !sprite.LayerMapTryGet(XenoVisualLayers.Base, out var layer))
@@ -145,21 +165,24 @@ public sealed class XenoVisualizerSystem : VisualizerSystem<XenoComponent>
         xeno.Comp.DrawDepth = (int) ev.DrawDepth;
     }
 
+    public override void Update(float frameTime)
+    {
+        var xenoQuery = EntityQueryEnumerator<XenoComponent>();
+        while (xenoQuery.MoveNext(out var uid, out _))
+        {
+            if (_animateQuery.HasComp(uid))
+                continue;
+
+            UpdateSprite(uid);
+        }
+    }
+
     public override void FrameUpdate(float frameTime)
     {
-        var animateQuery = EntityQueryEnumerator<XenoAnimateMovementComponent, InputMoverComponent, MobStateComponent, SpriteComponent>();
-        while (animateQuery.MoveNext(out var uid, out _, out var input, out var mobState, out var sprite))
+        var animateQuery = EntityQueryEnumerator<XenoAnimateMovementComponent>();
+        while (animateQuery.MoveNext(out var uid, out _))
         {
-            if (mobState.CurrentState == MobState.Alive)
-            {
-                UpdateSprite((uid, sprite, mobState, null, input));
-            }
-        }
-
-        var oviQuery = EntityQueryEnumerator<XenoOvipositorCapableComponent, SpriteComponent, AppearanceComponent>();
-        while (oviQuery.MoveNext(out var uid, out _, out var sprite, out var appearance))
-        {
-            UpdateSprite((uid, sprite, null, appearance));
+            UpdateSprite(uid);
         }
     }
 }

--- a/Content.Shared/_CM14/Xenos/XenoSystem.cs
+++ b/Content.Shared/_CM14/Xenos/XenoSystem.cs
@@ -39,6 +39,7 @@ public sealed class XenoSystem : EntitySystem
         SubscribeLocalEvent<XenoComponent, EntityUnpausedEvent>(OnXenoUnpaused);
         SubscribeLocalEvent<XenoComponent, GetAccessTagsEvent>(OnXenoGetAdditionalAccess);
         SubscribeLocalEvent<XenoComponent, NewXenoEvolvedComponent>(OnNewXenoEvolved);
+
         SubscribeLocalEvent<XenoWeedsComponent, StartCollideEvent>(OnWeedsStartCollide);
         SubscribeLocalEvent<XenoWeedsComponent, EndCollideEvent>(OnWeedsEndCollide);
     }
@@ -193,5 +194,4 @@ public sealed class XenoSystem : EntitySystem
 
         _toUpdate.Clear();
     }
-
 }

--- a/Resources/Prototypes/Alerts/alerts.yml
+++ b/Resources/Prototypes/Alerts/alerts.yml
@@ -5,6 +5,9 @@
   id: BaseAlertOrder
   order:
     - category: Health
+    - category: XenoNightVision
+    - category: XenoPlasma
+    - category: XenoArmor
     - category: Stamina
     - alertType: SuitPower
     - category: Internals

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/base_xeno.yml
@@ -148,26 +148,6 @@
       type: XenoWordQueenBui
   - type: TypingIndicator
     proto: alien
-  - type: AtmosExposed
-  - type: Temperature
-    heatDamageThreshold: 360
-    coldDamageThreshold: -150
-    currentTemperature: 310.15
-    coldDamage: #per second, scales with temperature & other constants
-      types:
-        Cold: 0.1
-    specificHeat: 42
-    heatDamage: #per second, scales with temperature & other constants
-      types:
-        Heat: 0.1
-  - type: ThermalRegulator
-    metabolismHeat: 800
-    radiatedHeat: 100
-    implicitHeatRegulation: 500
-    sweatHeatRegulation: 2000
-    shiveringHeatRegulation: 2000
-    normalBodyTemperature: 310.15
-    thermalRegulationTemperatureThreshold: 25
   - type: MovedByPressure
   - type: NoSlip
   - type: Pullable # TODO CM14 xeno pullable

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/base_xeno.yml
@@ -98,12 +98,6 @@
     groups:
       Flammable: [Touch]
       Extinguish: [Touch]
-  - type: Flammable
-    fireSpread: true
-    canResistFire: true
-    damage: #per second, scales with number of fire 'stacks'
-      types:
-        Heat: 1
   - type: FireVisuals
     sprite: Mobs/Effects/onfire.rsi
     normalState: Generic_mob_burning
@@ -195,6 +189,11 @@
     name: cm-xeno-name
     description: cm-xeno-description
     rules: cm-xeno-rules
+  - type: StatusEffects
+    allowed:
+    - Stun
+    - KnockedDown
+    - SlowedDown
 
 - type: entity
   abstract: true
@@ -272,12 +271,6 @@
   - CMXenoAI
   abstract: true
   components:
-  - type: DamageOnHighSpeedImpact
-    soundHit:
-      path: /Audio/Effects/hit_kick.ogg
-    damage:
-      types:
-        Blunt: 5
   - type: Tag
     tags:
     - DoorBumpOpener
@@ -299,3 +292,14 @@
     tailDamage:
       groups:
         Brute: 15
+
+- type: entity
+  abstract: true
+  id: CMXenoFlammable
+  components:
+  - type: Flammable
+    fireSpread: true
+    canResistFire: true
+    damage: #per second, scales with number of fire 'stacks'
+      types:
+        Heat: 3

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/boiler.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/boiler.yml
@@ -2,6 +2,7 @@
   parent:
   - CMXenoDeveloped
   - CMXenoTail
+  - CMXenoFlammable
   id: CMXenoBoiler
   name: Boiler
   description: A huge, grotesque xenomorph covered in glowing, oozing acid slime.

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/burrower.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/burrower.yml
@@ -2,6 +2,7 @@
   parent:
   - CMXenoDeveloped
   - CMXenoTail
+  - CMXenoFlammable
   id: CMXenoBurrower
   name: Burrower
   description: A beefy alien with sharp claws.

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/carrier.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/carrier.yml
@@ -2,6 +2,7 @@
   parent:
   - CMXenoDeveloped
   - CMXenoTail
+  - CMXenoFlammable
   id: CMXenoCarrier
   name: Carrier
   description: A strange-looking alien creature. It carries a number of scuttling jointed crablike creatures.

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/crusher.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/crusher.yml
@@ -2,6 +2,7 @@
   parent:
   - CMXenoDeveloped
   - CMXenoTail
+  - CMXenoFlammable
   id: CMXenoCrusher
   name: Crusher
   description: A huge alien with an enormous armored crest.

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/defender.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/defender.yml
@@ -2,6 +2,7 @@
   parent:
   - CMXenoDeveloped
   - CMXenoTail
+  - CMXenoFlammable
   id: CMXenoDefender
   name: Defender
   description: A alien with an armored crest.

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/drone.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/drone.yml
@@ -2,6 +2,7 @@
   parent:
   - CMXenoDeveloped
   - CMXenoTail
+  - CMXenoFlammable
   id: CMXenoDrone
   name: Drone
   description: An alien drone.

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/hivelord.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/hivelord.yml
@@ -2,6 +2,7 @@
   parent:
   - CMXenoDeveloped
   - CMXenoTail
+  - CMXenoFlammable
   id: CMXenoHivelord
   name: Hivelord
   description: A builder of really big hives.

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/hugger.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/hugger.yml
@@ -2,6 +2,7 @@
   parent:
   - CMXenoUndeveloped
   - CMXenoMelee
+  - CMXenoFlammable
   id: CMXenoHugger # TODO CM14 slowly die off weeds
   name: Facehugger
   components:

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/hugger.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/hugger.yml
@@ -1,5 +1,7 @@
 ﻿- type: entity
-  parent: [CMXenoUndeveloped, CMXenoMelee]
+  parent:
+  - CMXenoUndeveloped
+  - CMXenoMelee
   id: CMXenoHugger # TODO CM14 slowly die off weeds
   name: Facehugger
   components:

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/larva.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/larva.yml
@@ -1,5 +1,7 @@
 ﻿- type: entity
-  parent: CMXenoUndeveloped
+  parent:
+  - CMXenoUndeveloped
+  - CMXenoFlammable
   id: CMXenoLarva
   name: Larva
   components:

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/larva.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/larva.yml
@@ -45,3 +45,5 @@
         - SmallMobMask
         layer:
         - SmallMobLayer
+  - type: Flammable
+    canResistFire: false

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/lesser_drone.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/lesser_drone.yml
@@ -2,6 +2,7 @@
   parent:
   - CMXenoDeveloped
   - CMXenoTail
+  - CMXenoFlammable
   id: CMXenoLesserDrone
   name: Lesser Drone
   description: An alien drone. Looks... smaller.

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/lurker.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/lurker.yml
@@ -2,6 +2,7 @@
   parent:
   - CMXenoDeveloped
   - CMXenoTail
+  - CMXenoFlammable
   id: CMXenoLurker
   name: Lurker
   description: A beefy, fast alien with sharp claws.

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/praetorian.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/praetorian.yml
@@ -2,6 +2,7 @@
   parent:
   - CMXenoDeveloped
   - CMXenoTail
+  - CMXenoFlammable
   id: CMXenoPraetorian
   name: Praetorian
   description: A huge, looming beast of an alien.

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/ravager.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/ravager.yml
@@ -2,6 +2,7 @@
   parent:
   - CMXenoDeveloped
   - CMXenoTail
+  - CMXenoFlammable
   id: CMXenoRavager
   name: Ravager
   description: A huge, nasty red alien with enormous scythed claws.
@@ -43,3 +44,7 @@
   - type: Tackle
     threshold: 4
     stun: 9
+  - type: Flammable
+    damage:
+      types:
+        Heat: 0

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/runner.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/runner.yml
@@ -2,6 +2,7 @@
   parent:
   - CMXenoDeveloped
   - CMXenoTail
+  - CMXenoFlammable
   id: CMXenoRunner
   name: Runner
   description: A small red alien that looks like it could run fairly quickly...

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/sentinel.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/sentinel.yml
@@ -2,6 +2,7 @@
   parent:
   - CMXenoDeveloped
   - CMXenoTail
+  - CMXenoFlammable
   id: CMXenoSentinel
   name: Sentinel
   description: A slithery, spitting kind of alien.

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/spitter.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/spitter.yml
@@ -2,6 +2,7 @@
   parent:
   - CMXenoDeveloped
   - CMXenoTail
+  - CMXenoFlammable
   id: CMXenoSpitter
   name: Spitter
   description: A gross, oozing alien of some kind.

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/warrior.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/warrior.yml
@@ -2,6 +2,7 @@
   parent:
   - CMXenoDeveloped
   - CMXenoTail
+  - CMXenoFlammable
   id: CMXenoWarrior
   name: Warrior
   description: A beefy alien with an armored carapace.


### PR DESCRIPTION
## About the PR
Fixes #1274 

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: The xeno Queen can no longer catch fire.
- add: The xeno Ravager is now immune to damage dealt by catching fire.
- add: Xenos can now drop and roll to resist fire by clicking the fire status alert.