### PR TITLE
Increase range of xeno secrete resin to from 1 to 1.9 and require weeds to build

### DIFF
--- a/Content.Client/Popups/PopupSystem.cs
+++ b/Content.Client/Popups/PopupSystem.cs
@@ -5,7 +5,6 @@ using Content.Shared.Popups;
 using Robust.Client.Graphics;
 using Robust.Client.Input;
 using Robust.Client.Player;
-using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;
 using Robust.Shared.Configuration;
 using Robust.Shared.Map;
@@ -170,6 +169,15 @@ namespace Content.Client.Popups
 
             if (_timing.IsFirstTimePredicted)
                 PopupEntity(message, uid, recipient.Value, type);
+        }
+
+        public override void PopupClient(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupType type = PopupType.Small)
+        {
+            if (recipient == null)
+                return;
+
+            if (_timing.IsFirstTimePredicted)
+                PopupCoordinates(message, coordinates, recipient.Value, type);
         }
 
         public override void PopupEntity(string? message, EntityUid uid, PopupType type = PopupType.Small)

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -200,7 +200,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
         var coords = args.Coordinates;
 
-        if (!_actionsSystem.ValidateWorldTarget(user, coords, action))
+        if (!_actionsSystem.ValidateWorldTarget(user, coords, (actionId, action)))
         {
             // Invalid target.
             if (action.DeselectOnMiss)
@@ -235,7 +235,7 @@ public sealed class ActionUIController : UIController, IOnStateChanged<GameplayS
 
         var entity = args.EntityUid;
 
-        if (!_actionsSystem.ValidateEntityTarget(user, entity, action))
+        if (!_actionsSystem.ValidateEntityTarget(user, entity, (actionId, action)))
         {
             if (action.DeselectOnMiss)
                 StopTargeting();

--- a/Content.Server/Actions/ActionOnInteractSystem.cs
+++ b/Content.Server/Actions/ActionOnInteractSystem.cs
@@ -64,7 +64,7 @@ public sealed class ActionOnInteractSystem : EntitySystem
             var entOptions = GetValidActions<EntityTargetActionComponent>(component.ActionEntities, args.CanReach);
             for (var i = entOptions.Count - 1; i >= 0; i--)
             {
-                var action = entOptions[i].Comp;
+                var action = entOptions[i];
                 if (!_actions.ValidateEntityTarget(args.User, args.Target.Value, action))
                     entOptions.RemoveAt(i);
             }
@@ -88,7 +88,7 @@ public sealed class ActionOnInteractSystem : EntitySystem
         var options = GetValidActions<WorldTargetActionComponent>(component.ActionEntities, args.CanReach);
         for (var i = options.Count - 1; i >= 0; i--)
         {
-            var action = options[i].Comp;
+            var action = options[i];
             if (!_actions.ValidateWorldTarget(args.User, args.ClickLocation, action))
                 options.RemoveAt(i);
         }

--- a/Content.Server/Popups/PopupSystem.cs
+++ b/Content.Server/Popups/PopupSystem.cs
@@ -93,6 +93,10 @@ namespace Content.Server.Popups
             // do nothing duh its for client only
         }
 
+        public override void PopupClient(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupType type = PopupType.Small)
+        {
+        }
+
         public override void PopupEntity(string? message, EntityUid uid, ICommonSession recipient, PopupType type = PopupType.Small)
         {
             if (message == null)

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Content.Shared._CM14.Actions;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions.Events;
 using Content.Shared.Administration.Logs;
@@ -8,14 +9,13 @@ using Content.Shared.Hands;
 using Content.Shared.Interaction;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Mind;
-using Content.Shared.Mobs.Components;
+using Content.Shared.Rejuvenate;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Map;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
-using Content.Shared.Rejuvenate;
 
 namespace Content.Shared.Actions;
 
@@ -389,7 +389,7 @@ public abstract class SharedActionsSystem : EntitySystem
                 var targetWorldPos = _transformSystem.GetWorldPosition(entityTarget);
                 _rotateToFaceSystem.TryFaceCoordinates(user, targetWorldPos);
 
-                if (!ValidateEntityTarget(user, entityTarget, entityAction))
+                if (!ValidateEntityTarget(user, entityTarget, (actionEnt, entityAction)))
                     return;
 
                 _adminLogger.Add(LogType.Action,
@@ -413,7 +413,7 @@ public abstract class SharedActionsSystem : EntitySystem
                 var entityCoordinatesTarget = GetCoordinates(netCoordinatesTarget);
                 _rotateToFaceSystem.TryFaceCoordinates(user, entityCoordinatesTarget.ToMapPos(EntityManager, _transformSystem));
 
-                if (!ValidateWorldTarget(user, entityCoordinatesTarget, worldAction))
+                if (!ValidateWorldTarget(user, entityCoordinatesTarget, (actionEnt, worldAction)))
                     return;
 
                 _adminLogger.Add(LogType.Action,
@@ -445,7 +445,17 @@ public abstract class SharedActionsSystem : EntitySystem
         PerformAction(user, component, actionEnt, action, performEvent, curTime);
     }
 
-    public bool ValidateEntityTarget(EntityUid user, EntityUid target, EntityTargetActionComponent action)
+    public bool ValidateEntityTarget(EntityUid user, EntityUid target, Entity<EntityTargetActionComponent> actionEnt)
+    {
+        if (!ValidateEntityTargetBase(user, target, actionEnt))
+            return false;
+
+        var ev = new ValidateActionEntityTargetEvent(user, target);
+        RaiseLocalEvent(actionEnt, ref ev);
+        return !ev.Cancelled;
+    }
+
+    private bool ValidateEntityTargetBase(EntityUid user, EntityUid target, EntityTargetActionComponent action)
     {
         if (!target.IsValid() || Deleted(target))
             return false;
@@ -484,7 +494,17 @@ public abstract class SharedActionsSystem : EntitySystem
         return _interactionSystem.CanAccessViaStorage(user, target);
     }
 
-    public bool ValidateWorldTarget(EntityUid user, EntityCoordinates coords, WorldTargetActionComponent action)
+    public bool ValidateWorldTarget(EntityUid user, EntityCoordinates coords, Entity<WorldTargetActionComponent> action)
+    {
+        if (!ValidateWorldTargetBase(user, coords, action))
+            return false;
+
+        var ev = new ValidateActionWorldTargetEvent(user, coords);
+        RaiseLocalEvent(action, ref ev);
+        return !ev.Cancelled;
+    }
+
+    private bool ValidateWorldTargetBase(EntityUid user, EntityCoordinates coords, WorldTargetActionComponent action)
     {
         if (action.CheckCanInteract && !_actionBlockerSystem.CanInteract(user, null))
             return false;

--- a/Content.Shared/Popups/SharedPopupSystem.cs
+++ b/Content.Shared/Popups/SharedPopupSystem.cs
@@ -89,6 +89,12 @@ namespace Content.Shared.Popups
         public abstract void PopupClient(string? message, EntityUid uid, EntityUid? recipient, PopupType type = PopupType.Small);
 
         /// <summary>
+        /// Variant of <see cref="PopupCoordinates(string, EntityCoordinates, PopupType)"/> that only runs on the client, outside of prediction.
+        /// Useful for shared code that is always ran by both sides to avoid duplicate popups.
+        /// </summary>
+        public abstract void PopupClient(string? message, EntityCoordinates coordinates, EntityUid? recipient, PopupType type = PopupType.Small);
+
+        /// <summary>
         /// Variant of <see cref="PopupEntity(string, EntityUid, EntityUid, PopupType)"/> for use with prediction. The local client will show
         /// the popup to the recipient, and the server will show it to every other player in PVS range. If recipient is null, the local client
         /// will do nothing and the server will show the message to every player in PVS range.

--- a/Content.Shared/_CM14/Actions/ValidateActionEntityTargetEvent.cs
+++ b/Content.Shared/_CM14/Actions/ValidateActionEntityTargetEvent.cs
@@ -1,0 +1,4 @@
+﻿namespace Content.Shared._CM14.Actions;
+
+[ByRefEvent]
+public record struct ValidateActionEntityTargetEvent(EntityUid User, EntityUid Target, bool Cancelled = false);

--- a/Content.Shared/_CM14/Actions/ValidateActionWorldTargetEvent.cs
+++ b/Content.Shared/_CM14/Actions/ValidateActionWorldTargetEvent.cs
@@ -1,0 +1,6 @@
+﻿using Robust.Shared.Map;
+
+namespace Content.Shared._CM14.Actions;
+
+[ByRefEvent]
+public record struct ValidateActionWorldTargetEvent(EntityUid User, EntityCoordinates Target, bool Cancelled = false);

--- a/Content.Shared/_CM14/Xenos/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Construction/SharedXenoConstructionSystem.cs
@@ -66,7 +66,7 @@ public abstract class SharedXenoConstructionSystem : EntitySystem
         SubscribeLocalEvent<XenoWeedsComponent, AnchorStateChangedEvent>(OnWeedsAnchorChanged);
 
         SubscribeLocalEvent<XenoChooseConstructionActionComponent, XenoConstructionChosenEvent>(OnActionConstructionChosen);
-        SubscribeLocalEvent<XenoSecreteStructureActionComponent, ValidateActionWorldTargetEvent>(OnSecreteActionValidateTarget);
+        SubscribeLocalEvent<XenoConstructionActionComponent, ValidateActionWorldTargetEvent>(OnSecreteActionValidateTarget);
 
         SubscribeLocalEvent<HiveConstructionNodeComponent, ExaminedEvent>(OnHiveConstructionNodeExamined);
         SubscribeLocalEvent<HiveConstructionNodeComponent, InteractHandEvent>(OnHiveConstructionNodeInteractedHand);
@@ -249,7 +249,7 @@ public abstract class SharedXenoConstructionSystem : EntitySystem
         }
     }
 
-    private void OnSecreteActionValidateTarget(Entity<XenoSecreteStructureActionComponent> ent, ref ValidateActionWorldTargetEvent args)
+    private void OnSecreteActionValidateTarget(Entity<XenoConstructionActionComponent> ent, ref ValidateActionWorldTargetEvent args)
     {
         if (!TryComp(args.User, out XenoConstructionComponent? construction))
             return;

--- a/Content.Shared/_CM14/Xenos/Construction/SharedXenoConstructionSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Construction/SharedXenoConstructionSystem.cs
@@ -112,7 +112,6 @@ public abstract class SharedXenoConstructionSystem : EntitySystem
             return;
 
         xeno.Comp.BuildChoice = args.StructureId;
-
         Dirty(xeno);
 
         if (TryComp(xeno, out ActorComponent? actor))
@@ -364,7 +363,7 @@ public abstract class SharedXenoConstructionSystem : EntitySystem
         target = target.SnapToGrid(EntityManager, _map);
         if (!origin.InRange(EntityManager, _transform, target, range))
         {
-            _popup.PopupClient(Loc.GetString("cm-xeno-cant-reach-there"), xeno, xeno);
+            _popup.PopupClient(Loc.GetString("cm-xeno-cant-reach-there"), target, xeno);
             return false;
         }
 
@@ -376,26 +375,23 @@ public abstract class SharedXenoConstructionSystem : EntitySystem
         if (target.GetGridUid(EntityManager) is not { } gridId ||
             !TryComp(gridId, out MapGridComponent? grid))
         {
-            _popup.PopupClient("You can't build there!", xeno, xeno);
+            _popup.PopupClient("You can't build there!", target, xeno);
             return false;
         }
 
         target = target.SnapToGrid(EntityManager, _map);
         if (!IsOnWeeds((gridId, grid), target))
         {
-            _popup.PopupClient("You can only shape on weeds. Find some resin before you start building!", xeno, xeno);
+            _popup.PopupClient("You can only shape on weeds. Find some resin before you start building!", target, xeno);
             return false;
         }
 
         if (!InRangePopup(xeno, target, xeno.Comp.BuildRange.Float()))
-        {
-            _popup.PopupClient(Loc.GetString("cm-xeno-cant-reach-there"), xeno, xeno);
             return false;
-        }
 
         if (!TileSolidAndNotBlocked(target))
         {
-            _popup.PopupClient("You can't build there!", xeno, xeno);
+            _popup.PopupClient("You can't build there!", target, xeno);
             return false;
         }
 

--- a/Content.Shared/_CM14/Xenos/Construction/XenoConstructionActionComponent.cs
+++ b/Content.Shared/_CM14/Xenos/Construction/XenoConstructionActionComponent.cs
@@ -3,4 +3,4 @@
 namespace Content.Shared._CM14.Xenos.Construction;
 
 [RegisterComponent, NetworkedComponent]
-public sealed partial class XenoSecreteStructureActionComponent : Component;
+public sealed partial class XenoConstructionActionComponent : Component;

--- a/Content.Shared/_CM14/Xenos/Construction/XenoConstructionComponent.cs
+++ b/Content.Shared/_CM14/Xenos/Construction/XenoConstructionComponent.cs
@@ -10,7 +10,7 @@ namespace Content.Shared._CM14.Xenos.Construction;
 public sealed partial class XenoConstructionComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public FixedPoint2 BuildRange = 1;
+    public FixedPoint2 BuildRange = 1.9;
 
     [DataField, AutoNetworkedField]
     public List<EntProtoId> CanBuild = new();
@@ -22,7 +22,7 @@ public sealed partial class XenoConstructionComponent : Component
     public TimeSpan BuildDelay = TimeSpan.FromSeconds(4);
 
     [DataField, AutoNetworkedField]
-    public FixedPoint2 OrderConstructionRange = 1.5;
+    public FixedPoint2 OrderConstructionRange = 1.9;
 
     [DataField, AutoNetworkedField]
     public List<EntProtoId> CanOrderConstruction = new();

--- a/Content.Shared/_CM14/Xenos/Construction/XenoSecreteStructureActionComponent.cs
+++ b/Content.Shared/_CM14/Xenos/Construction/XenoSecreteStructureActionComponent.cs
@@ -1,0 +1,6 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._CM14.Xenos.Construction;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class XenoSecreteStructureActionComponent : Component;

--- a/Resources/Prototypes/_CM14/Actions/Xeno/xeno_construction_actions.yml
+++ b/Resources/Prototypes/_CM14/Actions/Xeno/xeno_construction_actions.yml
@@ -36,7 +36,7 @@
       state: secrete_resin
     event: !type:XenoSecreteStructureActionEvent
     deselectOnMiss: false
-    range: 10000
+    range: 20
   - type: XenoConstructionAction
 
 - type: entity

--- a/Resources/Prototypes/_CM14/Actions/Xeno/xeno_construction_actions.yml
+++ b/Resources/Prototypes/_CM14/Actions/Xeno/xeno_construction_actions.yml
@@ -35,6 +35,9 @@
       sprite: _CM14/Actions/xeno_actions.rsi
       state: secrete_resin
     event: !type:XenoSecreteStructureActionEvent
+    deselectOnMiss: false
+    range: 10000
+  - type: XenoSecreteStructureAction
 
 - type: entity
   id: ActionXenoOrderConstruction

--- a/Resources/Prototypes/_CM14/Actions/Xeno/xeno_construction_actions.yml
+++ b/Resources/Prototypes/_CM14/Actions/Xeno/xeno_construction_actions.yml
@@ -51,5 +51,5 @@
       state: morph_resin
     event: !type:XenoOrderConstructionActionEvent
     deselectOnMiss: false
-    range: 10000
+    range: 20
   - type: XenoConstructionAction

--- a/Resources/Prototypes/_CM14/Actions/Xeno/xeno_construction_actions.yml
+++ b/Resources/Prototypes/_CM14/Actions/Xeno/xeno_construction_actions.yml
@@ -37,7 +37,7 @@
     event: !type:XenoSecreteStructureActionEvent
     deselectOnMiss: false
     range: 10000
-  - type: XenoSecreteStructureAction
+  - type: XenoConstructionAction
 
 - type: entity
   id: ActionXenoOrderConstruction
@@ -50,3 +50,6 @@
       sprite: _CM14/Actions/xeno_actions.rsi
       state: morph_resin
     event: !type:XenoOrderConstructionActionEvent
+    deselectOnMiss: false
+    range: 10000
+  - type: XenoConstructionAction


### PR DESCRIPTION
## About the PR
Fixes #1292 
Includes the changes in https://github.com/space-wizards/space-station-14/pull/27230 and https://github.com/space-wizards/space-station-14/pull/27231

## Media
https://github.com/CM-14/CM-14/assets/10968691/dcd60df4-14af-4b9e-8569-ad4fb2e36911

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed xeno construction range being inconsistent depending on where you click on a tile.
- tweak: Increased xeno construction range from 1 tile to 1.9 tiles.
- tweak: Xeno construction now require weeds on the tile.
- tweak: If a location isn't valid for xeno construction, the action will remain selected but show a popup for why it is not valid.
