### PR TITLE
Make medically-unskilled marines have a 3 second do after when using auto-injectors

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/HypospraySystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/HypospraySystem.cs
@@ -1,8 +1,14 @@
-using Content.Shared.Chemistry.EntitySystems;
+using System.Linq;
+using Content.Server.Body.Components;
+using Content.Server.Chemistry.Containers.EntitySystems;
+using Content.Server.Interaction;
+using Content.Shared._CM14.Marines.Skills;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;
+using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Database;
+using Content.Shared.DoAfter;
 using Content.Shared.FixedPoint;
 using Content.Shared.Forensics;
 using Content.Shared.IdentityManagement;
@@ -11,12 +17,6 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Timing;
 using Content.Shared.Weapons.Melee.Events;
-using Content.Server.Interaction;
-using Content.Server.Body.Components;
-using Content.Server.Chemistry.Containers.EntitySystems;
-using Robust.Shared.GameStates;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Robust.Server.Audio;
 
 namespace Content.Server.Chemistry.EntitySystems;
@@ -24,6 +24,7 @@ namespace Content.Server.Chemistry.EntitySystems;
 public sealed class HypospraySystem : SharedHypospraySystem
 {
     [Dependency] private readonly AudioSystem _audio = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly InteractionSystem _interaction = default!;
     [Dependency] private readonly SolutionContainerSystem _solutionContainerSystem = default!;
 
@@ -34,6 +35,82 @@ public sealed class HypospraySystem : SharedHypospraySystem
         SubscribeLocalEvent<HyposprayComponent, AfterInteractEvent>(OnAfterInteract);
         SubscribeLocalEvent<HyposprayComponent, MeleeHitEvent>(OnAttack);
         SubscribeLocalEvent<HyposprayComponent, UseInHandEvent>(OnUseInHand);
+        SubscribeLocalEvent<HyposprayComponent, HyposprayDoAfterEvent>(OnHyposprayDoAfter);
+    }
+
+    private void OnHyposprayDoAfter(Entity<HyposprayComponent> ent, ref HyposprayDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled)
+            return;
+
+        if (args.Target is not { } target)
+            return;
+
+        args.Handled = true;
+
+        var user = args.User;
+        var component = ent.Comp;
+        var uid = ent.Owner;
+        string? msgFormat = null;
+
+        if (target == user)
+            msgFormat = "hypospray-component-inject-self-message";
+        else if (EligibleEntity(user, EntityManager, component) && _interaction.TryRollClumsy(user, component.ClumsyFailChance))
+        {
+            msgFormat = "hypospray-component-inject-self-clumsy-message";
+            target = user;
+        }
+
+        if (!_solutionContainers.TryGetSolution(uid, component.SolutionName, out var hypoSpraySoln, out var hypoSpraySolution) || hypoSpraySolution.Volume == 0)
+        {
+            _popup.PopupEntity(Loc.GetString("hypospray-component-empty-message"), target, user);
+            return;
+        }
+
+        if (!_solutionContainers.TryGetInjectableSolution(target, out var targetSoln, out var targetSolution))
+        {
+            _popup.PopupEntity(Loc.GetString("hypospray-cant-inject", ("target", Identity.Entity(target, EntityManager))), target, user);
+            return;
+        }
+
+        _popup.PopupEntity(Loc.GetString(msgFormat ?? "hypospray-component-inject-other-message", ("other", target)), target, user);
+
+        if (target != user)
+        {
+            _popup.PopupEntity(Loc.GetString("hypospray-component-feel-prick-message"), target, target);
+            // TODO: This should just be using melee attacks...
+            // meleeSys.SendLunge(angle, user);
+        }
+
+        _audio.PlayPvs(component.InjectSound, user);
+
+        // Medipens and such use this system and don't have a delay, requiring extra checks
+        // BeginDelay function returns if item is already on delay
+        if (TryComp(ent, out UseDelayComponent? delayComp))
+            _useDelay.TryResetDelay((uid, delayComp));
+
+        // Get transfer amount. May be smaller than component.TransferAmount if not enough room
+        var realTransferAmount = FixedPoint2.Min(component.TransferAmount, targetSolution.AvailableVolume);
+
+        if (realTransferAmount <= 0)
+        {
+            _popup.PopupEntity(Loc.GetString("hypospray-component-transfer-already-full-message", ("owner", target)), target, user);
+            return;
+        }
+
+        // Move units from attackSolution to targetSolution
+        var removedSolution = _solutionContainers.SplitSolution(hypoSpraySoln.Value, realTransferAmount);
+
+        if (!targetSolution.CanAddSolution(removedSolution))
+            return;
+        _reactiveSystem.DoEntityReaction(target, removedSolution, ReactionMethod.Injection);
+        _solutionContainers.TryAddSolution(targetSoln.Value, removedSolution);
+
+        var ev = new TransferDnaEvent { Donor = target, Recipient = uid };
+        RaiseLocalEvent(target, ref ev);
+
+        // same LogType as syringes...
+        _adminLogger.Add(LogType.ForceFeed, $"{EntityManager.ToPrettyString(user):user} injected {EntityManager.ToPrettyString(target):target} with a solution {SolutionContainerSystem.ToPrettyString(removedSolution):removedSolution} using a {EntityManager.ToPrettyString(uid):using}");
     }
 
     private void UseHypospray(Entity<HyposprayComponent> entity, EntityUid target, EntityUid user)
@@ -87,66 +164,14 @@ public sealed class HypospraySystem : SharedHypospraySystem
                 return false;
         }
 
-        string? msgFormat = null;
-
-        if (target == user)
-            msgFormat = "hypospray-component-inject-self-message";
-        else if (EligibleEntity(user, EntityManager, component) && _interaction.TryRollClumsy(user, component.ClumsyFailChance))
+        var attemptEv = new AttemptHyposprayUseEvent(user, target, TimeSpan.Zero);
+        RaiseLocalEvent(entity, ref attemptEv);
+        var doAfter = new HyposprayDoAfterEvent();
+        var args = new DoAfterArgs(EntityManager, user, attemptEv.DoAfter, doAfter, entity, target, entity)
         {
-            msgFormat = "hypospray-component-inject-self-clumsy-message";
-            target = user;
-        }
-
-        if (!_solutionContainers.TryGetSolution(uid, component.SolutionName, out var hypoSpraySoln, out var hypoSpraySolution) || hypoSpraySolution.Volume == 0)
-        {
-            _popup.PopupEntity(Loc.GetString("hypospray-component-empty-message"), target, user);
-            return true;
-        }
-
-        if (!_solutionContainers.TryGetInjectableSolution(target, out var targetSoln, out var targetSolution))
-        {
-            _popup.PopupEntity(Loc.GetString("hypospray-cant-inject", ("target", Identity.Entity(target, EntityManager))), target, user);
-            return false;
-        }
-
-        _popup.PopupEntity(Loc.GetString(msgFormat ?? "hypospray-component-inject-other-message", ("other", target)), target, user);
-
-        if (target != user)
-        {
-            _popup.PopupEntity(Loc.GetString("hypospray-component-feel-prick-message"), target, target);
-            // TODO: This should just be using melee attacks...
-            // meleeSys.SendLunge(angle, user);
-        }
-
-        _audio.PlayPvs(component.InjectSound, user);
-
-        // Medipens and such use this system and don't have a delay, requiring extra checks
-        // BeginDelay function returns if item is already on delay
-        if (delayComp != null)
-            _useDelay.TryResetDelay((uid, delayComp));
-
-        // Get transfer amount. May be smaller than component.TransferAmount if not enough room
-        var realTransferAmount = FixedPoint2.Min(component.TransferAmount, targetSolution.AvailableVolume);
-
-        if (realTransferAmount <= 0)
-        {
-            _popup.PopupEntity(Loc.GetString("hypospray-component-transfer-already-full-message", ("owner", target)), target, user);
-            return true;
-        }
-
-        // Move units from attackSolution to targetSolution
-        var removedSolution = _solutionContainers.SplitSolution(hypoSpraySoln.Value, realTransferAmount);
-
-        if (!targetSolution.CanAddSolution(removedSolution))
-            return true;
-        _reactiveSystem.DoEntityReaction(target, removedSolution, ReactionMethod.Injection);
-        _solutionContainers.TryAddSolution(targetSoln.Value, removedSolution);
-
-        var ev = new TransferDnaEvent { Donor = target, Recipient = uid };
-        RaiseLocalEvent(target, ref ev);
-
-        // same LogType as syringes...
-        _adminLogger.Add(LogType.ForceFeed, $"{EntityManager.ToPrettyString(user):user} injected {EntityManager.ToPrettyString(target):target} with a solution {SolutionContainerSystem.ToPrettyString(removedSolution):removedSolution} using a {EntityManager.ToPrettyString(uid):using}");
+            BreakOnMove = true
+        };
+        _doAfter.TryStartDoAfter(args);
 
         return true;
     }

--- a/Content.Shared/_CM14/Marines/Skills/AttemptHyposprayUseEvent.cs
+++ b/Content.Shared/_CM14/Marines/Skills/AttemptHyposprayUseEvent.cs
@@ -1,0 +1,11 @@
+﻿namespace Content.Shared._CM14.Marines.Skills;
+
+[ByRefEvent]
+public record struct AttemptHyposprayUseEvent(EntityUid User, EntityUid Target, TimeSpan DoAfter)
+{
+    public void MaxDoAfter(TimeSpan b)
+    {
+        if (DoAfter < b)
+            DoAfter = b;
+    }
+}

--- a/Content.Shared/_CM14/Marines/Skills/HyposprayDoAfterEvent.cs
+++ b/Content.Shared/_CM14/Marines/Skills/HyposprayDoAfterEvent.cs
@@ -1,0 +1,7 @@
+﻿using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._CM14.Marines.Skills;
+
+[Serializable, NetSerializable]
+public sealed partial class HyposprayDoAfterEvent : SimpleDoAfterEvent;

--- a/Content.Shared/_CM14/Marines/Skills/MedicallyUnskilledDoAfterComponent.cs
+++ b/Content.Shared/_CM14/Marines/Skills/MedicallyUnskilledDoAfterComponent.cs
@@ -1,0 +1,14 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._CM14.Marines.Skills;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SkillsSystem))]
+public sealed partial class MedicallyUnskilledDoAfterComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public int Min = 1;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan DoAfter = TimeSpan.FromSeconds(3);
+}

--- a/Content.Shared/_CM14/Marines/Skills/SkillsSystem.cs
+++ b/Content.Shared/_CM14/Marines/Skills/SkillsSystem.cs
@@ -1,0 +1,18 @@
+﻿namespace Content.Shared._CM14.Marines.Skills;
+
+public sealed class SkillsSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<MedicallyUnskilledDoAfterComponent, AttemptHyposprayUseEvent>(OnAttemptHyposprayUse);
+    }
+
+    private void OnAttemptHyposprayUse(Entity<MedicallyUnskilledDoAfterComponent> ent, ref AttemptHyposprayUseEvent args)
+    {
+        if (!TryComp(args.User, out SkillsComponent? skills) ||
+            skills.Medical < ent.Comp.Min)
+        {
+            args.MaxDoAfter(ent.Comp.DoAfter);
+        }
+    }
+}

--- a/Resources/Prototypes/_CM14/Entities/Objects/Medical/auto_injectors.yml
+++ b/Resources/Prototypes/_CM14/Entities/Objects/Medical/auto_injectors.yml
@@ -36,11 +36,12 @@
   - type: Tag
     tags:
     - CMAutoInjector
+  - type: MedicallyUnskilledDoAfter
 
 - type: entity
   parent: CMAutoInjector
   id: CMEmergencyInjector
-  name: emergency auto-injector
+  name: emergency auto-injector (CAUTION)
   description: An auto-injector loaded with a special cocktail of chemicals, to be used in a life-threatening situations. Contains 30 units of bicaridine, 30 units of kelotane and 20 units of epinephrine.
   components:
   - type: Sprite
@@ -67,6 +68,9 @@
           Quantity: 20
   - type: SolutionContainerVisuals
     maxFillLevels: 1
+  - type: MedicallyUnskilledDoAfter
+    min: 0
+    doAfter: 0
 
 - type: entity
   parent: CMAutoInjector


### PR DESCRIPTION
## About the PR
Resolves #1269 

## Media
https://github.com/CM-14/CM-14/assets/10968691/598ff63e-55e9-438e-bc47-003693a5e457

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Medically-unskilled marines now have a 3 second do after delay when using auto-injectors, except for the emergency one.
