### PR TITLE
fires no longer spread between mobs

### DIFF
--- a/Resources/Prototypes/_CM14/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Species/base.yml
@@ -66,7 +66,7 @@
       Female: FemaleHuman
       Unsexed: MaleHuman
   - type: Flammable
-    fireSpread: true
+    fireSpread: false
     canResistFire: true
     damage:
       types:

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/base_xeno.yml
@@ -278,7 +278,7 @@
   id: CMXenoFlammable
   components:
   - type: Flammable
-    fireSpread: true
+    fireSpread: false
     canResistFire: true
     damage: #per second, scales with number of fire 'stacks'
       types:


### PR DESCRIPTION
- fix #2002

**Changelog**
:cl:
- fix: Fixed burning marines and xenos being able to set others on fire.