### PR TITLE
Fix xenos not being able to pry open doors by left clicking on them

### DIFF
--- a/Content.Shared/Prying/Systems/PryingSystem.cs
+++ b/Content.Shared/Prying/Systems/PryingSystem.cs
@@ -1,15 +1,14 @@
-using Content.Shared.Prying.Components;
-using Content.Shared.Verbs;
-using Content.Shared.DoAfter;
-using Robust.Shared.Serialization;
+using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
+using Content.Shared.DoAfter;
 using Content.Shared.Doors.Components;
-using System.Diagnostics.CodeAnalysis;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
-using Robust.Shared.Audio;
+using Content.Shared.Prying.Components;
+using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Serialization;
 using PryUnpoweredComponent = Content.Shared.Prying.Components.PryUnpoweredComponent;
 
 namespace Content.Shared.Prying.Systems;
@@ -99,14 +98,16 @@ public sealed class PryingSystem : EntitySystem
             // to be marked as handled.
             return true;
 
-        return StartPry(target, user, null, 0.1f, out id); // hand-prying is much slower
+        // hand-prying is much slower
+        var modifier = CompOrNull<PryingComponent>(user)?.SpeedModifier ?? 0.1f;
+        return StartPry(target, user, null, modifier, out id);
     }
 
     private bool CanPry(EntityUid target, EntityUid user, out string? message, PryingComponent? comp = null)
     {
         BeforePryEvent canev;
 
-        if (comp != null)
+        if (comp != null || Resolve(user, ref comp))
         {
             canev = new BeforePryEvent(user, comp.PryPowered, comp.Force);
         }

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/base_xeno.yml
@@ -180,14 +180,11 @@
   id: CMXenoPrying
   components:
   - type: Tool
-    speed: 1.5
     qualities:
     - Prying
   - type: Prying
-    pryPowered: !type:Bool
-      true
-    force: !type:Bool
-      true
+    pryPowered: true
+    speedModifier: 2.7
     useSound:
       path: /Audio/Items/crowbar.ogg
 


### PR DESCRIPTION
## About the PR
Fixes #2000 
Includes the changes in https://github.com/space-wizards/space-station-14/pull/27349

## Media
https://github.com/CM-14/CM-14/assets/10968691/0d2f15d0-096d-4e29-9127-610163545e9e

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed xenos not being able to pry doors by left clicking on them.
- tweak: Xenos can now pry open doors in 5 seconds.
