### PR TITLE
Xeno tail stab fixes and tweaks

### DIFF
--- a/Content.Client/_CM14/Xenos/Stab/XenoTailStabSystem.cs
+++ b/Content.Client/_CM14/Xenos/Stab/XenoTailStabSystem.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using Content.Client.Interactable;
 using Content.Shared._CM14.Xenos.Stab;
 using Robust.Client.Animations;
 using Robust.Client.GameObjects;
@@ -15,6 +16,7 @@ public sealed class XenoTailStabSystem : SharedXenoTailStabSystem
 {
     [Dependency] private readonly AnimationPlayerSystem _animation = default!;
     [Dependency] private readonly IConsoleHost _console = default!;
+    [Dependency] private readonly InteractionSystem _interaction = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IOverlayManager _overlays = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
@@ -73,6 +75,11 @@ public sealed class XenoTailStabSystem : SharedXenoTailStabSystem
 
         // lie by 20% so the player feels less bad about missing
         var distance = localPos.Length() * 0.80f;
+
+        var origin = _transform.GetMapCoordinates(user);
+        var unobstructedDistance = _interaction.UnobstructedDistance(origin, origin.Offset(localPos));
+        if (distance > unobstructedDistance)
+            distance = unobstructedDistance;
 
         var startOffset = sprite.Rotation.RotateVec(new Vector2(0, -distance / 5f));
         var endOffset = sprite.Rotation.RotateVec(new Vector2(0, -distance));

--- a/Content.Shared/_CM14/Xenos/Stab/SharedXenoTailStabSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Stab/SharedXenoTailStabSystem.cs
@@ -27,7 +27,6 @@ public abstract class SharedXenoTailStabSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedColorFlashEffectSystem _colorFlash = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
-    [Dependency] private readonly FixtureSystem _fixtures = default!;
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;

--- a/Content.Shared/_CM14/Xenos/Stab/XenoTailStabActionComponent.cs
+++ b/Content.Shared/_CM14/Xenos/Stab/XenoTailStabActionComponent.cs
@@ -1,0 +1,11 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._CM14.Xenos.Stab;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedXenoTailStabSystem))]
+public sealed partial class XenoTailStabActionComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public TimeSpan MissCooldown = TimeSpan.FromSeconds(1);
+}

--- a/Content.Shared/_CM14/Xenos/XenoComponent.cs
+++ b/Content.Shared/_CM14/Xenos/XenoComponent.cs
@@ -26,7 +26,7 @@ public sealed partial class XenoComponent : Component
     public TimeSpan NextRegenTime;
 
     [DataField, AutoNetworkedField]
-    public EntityUid Hive;
+    public EntityUid? Hive;
 
     [DataField, AutoNetworkedField]
     public HashSet<ProtoId<AccessLevelPrototype>> AccessLevels = new() { "CMAccessXeno" };

--- a/Resources/Prototypes/_CM14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_CM14/Actions/Xeno/xeno_offense_actions.yml
@@ -36,6 +36,7 @@
     range: 15
     useDelay: 10
     checkCanAccess: false
+  - type: XenoTailStabAction
 
 - type: entity
   id: ActionXenoLeap

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/base_xeno.yml
@@ -271,7 +271,7 @@
   - type: XenoTailStab
     tailDamage:
       groups:
-        Brute: 15
+        Brute: 30
 
 - type: entity
   abstract: true


### PR DESCRIPTION
## About the PR
Fixes #1990 
See #1167 

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed being able to hit friendly xenos with a tail stab and being able to hit marines with it through walls.
- tweak: The xeno tail stab can now hit 3 marines maximum and has a one second cooldown if it misses.