### PR TITLE
Make xenos unscannable with the hf2 health analyzer

### DIFF
--- a/Content.Shared/_CM14/Medical/Scanner/HealthScannerAttemptTargetEvent.cs
+++ b/Content.Shared/_CM14/Medical/Scanner/HealthScannerAttemptTargetEvent.cs
@@ -1,0 +1,4 @@
+﻿namespace Content.Shared._CM14.Medical.Scanner;
+
+[ByRefEvent]
+public record struct HealthScannerAttemptTargetEvent(string? Popup = null, bool Cancelled = false);

--- a/Content.Shared/_CM14/Xenos/XenoSystem.cs
+++ b/Content.Shared/_CM14/Xenos/XenoSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared._CM14.Marines;
+using Content.Shared._CM14.Medical.Scanner;
 using Content.Shared._CM14.Xenos.Construction;
 using Content.Shared._CM14.Xenos.Evolution;
 using Content.Shared._CM14.Xenos.Hive;
@@ -43,6 +44,7 @@ public sealed class XenoSystem : EntitySystem
         SubscribeLocalEvent<XenoComponent, MapInitEvent>(OnXenoMapInit);
         SubscribeLocalEvent<XenoComponent, GetAccessTagsEvent>(OnXenoGetAdditionalAccess);
         SubscribeLocalEvent<XenoComponent, NewXenoEvolvedComponent>(OnNewXenoEvolved);
+        SubscribeLocalEvent<XenoComponent, HealthScannerAttemptTargetEvent>(OnXenoHealthScannerAttemptTarget);
 
         SubscribeLocalEvent<XenoWeedsComponent, StartCollideEvent>(OnWeedsStartCollide);
         SubscribeLocalEvent<XenoWeedsComponent, EndCollideEvent>(OnWeedsEndCollide);
@@ -73,6 +75,12 @@ public sealed class XenoSystem : EntitySystem
     {
         var oldRotation = _transform.GetWorldRotation(args.OldXeno);
         _transform.SetWorldRotation(newXeno, oldRotation);
+    }
+
+    private void OnXenoHealthScannerAttemptTarget(Entity<XenoComponent> ent, ref HealthScannerAttemptTargetEvent args)
+    {
+        args.Popup = "The scanner can't make sense of this creature.";
+        args.Cancelled = true;
     }
 
     private void OnWeedsStartCollide(Entity<XenoWeedsComponent> ent, ref StartCollideEvent args)


### PR DESCRIPTION
## About the PR
Fixes #1997 

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed xenos being scannable with the hf2 health analyzer.