### PR TITLE
Make huggers unable to melee or tackle

### DIFF
--- a/Content.Shared/_CM14/Xenos/Hugger/SharedXenoHuggerSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Hugger/SharedXenoHuggerSystem.cs
@@ -169,6 +169,9 @@ public abstract class SharedXenoHuggerSystem : EntitySystem
             return false;
         }
 
+        if (_mobState.IsDead(victim))
+            return false;
+
         return true;
     }
 

--- a/Content.Shared/_CM14/Xenos/Hugger/SharedXenoHuggerSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Hugger/SharedXenoHuggerSystem.cs
@@ -1,10 +1,12 @@
 ﻿using Content.Shared._CM14.Xenos.Leap;
 using Content.Shared.DoAfter;
 using Content.Shared.Eye.Blinding.Systems;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.Popups;
 using Content.Shared.Standing;
 using Content.Shared.Stunnable;
 using Robust.Shared.Audio.Systems;
@@ -23,6 +25,7 @@ public abstract class SharedXenoHuggerSystem : EntitySystem
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
@@ -35,6 +38,7 @@ public abstract class SharedXenoHuggerSystem : EntitySystem
 
         SubscribeLocalEvent<XenoHuggerComponent, XenoLeapHitEvent>(OnHuggerLeapHit);
         SubscribeLocalEvent<XenoHuggerComponent, AfterInteractEvent>(OnHuggerAfterInteract);
+        SubscribeLocalEvent<XenoHuggerComponent, DoAfterAttemptEvent<AttachHuggerDoAfterEvent>>(OnHuggerAttachDoAfterAttempt);
         SubscribeLocalEvent<XenoHuggerComponent, AttachHuggerDoAfterEvent>(OnHuggerAttachDoAfter);
 
         SubscribeLocalEvent<HuggerSpentComponent, MapInitEvent>(OnHuggerSpentMapInit);
@@ -70,7 +74,7 @@ public abstract class SharedXenoHuggerSystem : EntitySystem
     {
         var coordinates = _transform.GetMoverCoordinates(hugger);
         if (coordinates.InRange(EntityManager, _transform, args.Leaping.Origin, hugger.Comp.HugRange))
-            Hug(hugger, args.Hit);
+            Hug(hugger, args.Hit, false);
     }
 
     private void OnHuggerAfterInteract(Entity<XenoHuggerComponent> ent, ref AfterInteractEvent args)
@@ -80,6 +84,18 @@ public abstract class SharedXenoHuggerSystem : EntitySystem
 
         if (StartHug(ent, args.Target.Value, ent))
             args.Handled = true;
+    }
+
+    private void OnHuggerAttachDoAfterAttempt(Entity<XenoHuggerComponent> ent, ref DoAfterAttemptEvent<AttachHuggerDoAfterEvent> args)
+    {
+        if (args.DoAfter.Args.Target is not { } target)
+        {
+            args.Cancel();
+            return;
+        }
+
+        if (!CanHugPopup(ent, target, ent))
+            args.Cancel();
     }
 
     private void OnHuggerAttachDoAfter(Entity<XenoHuggerComponent> ent, ref AttachHuggerDoAfterEvent args)
@@ -141,43 +157,56 @@ public abstract class SharedXenoHuggerSystem : EntitySystem
 
     private bool StartHug(Entity<XenoHuggerComponent> hugger, EntityUid victim, EntityUid user)
     {
-        if (!CanHug(hugger, victim))
+        if (!CanHugPopup(hugger, victim, user))
             return false;
 
         var ev = new AttachHuggerDoAfterEvent();
         var doAfter = new DoAfterArgs(EntityManager, user, hugger.Comp.ManualAttachDelay, ev, hugger, victim)
         {
-            BreakOnMove = true
+            BreakOnMove = true,
+            AttemptFrequency = AttemptFrequency.EveryTick
         };
         _doAfter.TryStartDoAfter(doAfter);
 
         return true;
     }
 
-    private bool CanHug(Entity<XenoHuggerComponent> hugger, EntityUid victim)
+    private bool CanHugPopup(Entity<XenoHuggerComponent> hugger, EntityUid victim, EntityUid user, bool popup = true)
     {
+        var victimIdentity = Identity.Name(victim, EntityManager, hugger);
         if (!HasComp<HuggableComponent>(victim) ||
             HasComp<HuggerSpentComponent>(hugger) ||
             HasComp<VictimHuggedComponent>(victim))
         {
+            if (popup)
+                _popup.PopupClient($"You can't facehug {victimIdentity}!", victim, hugger, PopupType.MediumCaution);
+
             return false;
         }
 
         if (TryComp(victim, out StandingStateComponent? standing) &&
             !_standing.IsDown(victim, standing))
         {
+            if (popup)
+                _popup.PopupClient($"You can't reach {victimIdentity}, they need to be lying down!", victim, hugger, PopupType.MediumCaution);
+
             return false;
         }
 
         if (_mobState.IsDead(victim))
+        {
+            if (popup)
+                _popup.PopupClient("You can't facehug the dead!", victim, hugger, PopupType.MediumCaution);
+
             return false;
+        }
 
         return true;
     }
 
-    private bool Hug(Entity<XenoHuggerComponent> hugger, EntityUid victim)
+    private bool Hug(Entity<XenoHuggerComponent> hugger, EntityUid victim, bool popup = true)
     {
-        if (!CanHug(hugger, victim))
+        if (!CanHugPopup(hugger, victim, hugger, popup))
             return false;
 
         var victimComp = EnsureComp<VictimHuggedComponent>(victim);

--- a/Content.Shared/_CM14/Xenos/Hugger/SharedXenoHuggerSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Hugger/SharedXenoHuggerSystem.cs
@@ -82,7 +82,7 @@ public abstract class SharedXenoHuggerSystem : EntitySystem
         if (args.Target == null)
             return;
 
-        if (StartHug(ent, args.Target.Value, ent))
+        if (StartHug(ent, args.Target.Value, args.User))
             args.Handled = true;
     }
 
@@ -179,7 +179,7 @@ public abstract class SharedXenoHuggerSystem : EntitySystem
             HasComp<VictimHuggedComponent>(victim))
         {
             if (popup)
-                _popup.PopupClient($"You can't facehug {victimIdentity}!", victim, hugger, PopupType.MediumCaution);
+                _popup.PopupClient($"You can't facehug {victimIdentity}!", victim, user, PopupType.MediumCaution);
 
             return false;
         }
@@ -188,7 +188,7 @@ public abstract class SharedXenoHuggerSystem : EntitySystem
             !_standing.IsDown(victim, standing))
         {
             if (popup)
-                _popup.PopupClient($"You can't reach {victimIdentity}, they need to be lying down!", victim, hugger, PopupType.MediumCaution);
+                _popup.PopupClient($"You can't reach {victimIdentity}, they need to be lying down!", victim, user, PopupType.MediumCaution);
 
             return false;
         }
@@ -196,7 +196,7 @@ public abstract class SharedXenoHuggerSystem : EntitySystem
         if (_mobState.IsDead(victim))
         {
             if (popup)
-                _popup.PopupClient("You can't facehug the dead!", victim, hugger, PopupType.MediumCaution);
+                _popup.PopupClient("You can't facehug the dead!", victim, user, PopupType.MediumCaution);
 
             return false;
         }

--- a/Content.Shared/_CM14/Xenos/Leap/SharedXenoLeapSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Leap/SharedXenoLeapSystem.cs
@@ -115,10 +115,19 @@ public sealed class SharedXenoLeapSystem : EntitySystem
     {
         var marineId = args.OtherEntity;
 
-        if (EnsureComp<LeapIncapacitatedComponent>(marineId, out var victim))
+        if (!_marineQuery.TryGetComponent(marineId, out var marine))
             return;
 
-        if (!_marineQuery.TryGetComponent(marineId, out var marine))
+        if (HasComp<LeapIncapacitatedComponent>(marineId))
+            return;
+
+        if (xeno.Comp.KnockedDown)
+            return;
+
+        xeno.Comp.KnockedDown = true;
+        Dirty(xeno);
+
+        if (EnsureComp<LeapIncapacitatedComponent>(marineId, out var victim))
             return;
 
         if (_physicsQuery.TryGetComponent(xeno, out var physics))

--- a/Content.Shared/_CM14/Xenos/Leap/XenoLeapingComponent.cs
+++ b/Content.Shared/_CM14/Xenos/Leap/XenoLeapingComponent.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 namespace Content.Shared._CM14.Xenos.Leap;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
+[Access(typeof(SharedXenoLeapSystem))]
 public sealed partial class XenoLeapingComponent : Component
 {
     [DataField, AutoNetworkedField]
@@ -19,4 +20,7 @@ public sealed partial class XenoLeapingComponent : Component
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan LeapEndTime;
+
+    [DataField, AutoNetworkedField]
+    public bool KnockedDown;
 }

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/hugger.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/hugger.yml
@@ -1,7 +1,6 @@
 ﻿- type: entity
   parent:
   - CMXenoUndeveloped
-  - CMXenoMelee
   - CMXenoFlammable
   id: CMXenoHugger # TODO CM14 slowly die off weeds
   name: Facehugger


### PR DESCRIPTION
## About the PR
Fixes #1973 
Fixes #1975 
Fixes #1982 

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed huggers being able to melee attack and tackle.
- fix: Fixed huggers being able to hug dead marines.
- tweak: Leaping xenos can now only hit a max of one marine in a single leap.
