### PR TITLE
Remove chestbursters from dead marines when they try to burst

### DIFF
--- a/Content.Shared/_CM14/Xenos/Hugger/SharedXenoHuggerSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Hugger/SharedXenoHuggerSystem.cs
@@ -241,6 +241,12 @@ public abstract class SharedXenoHuggerSystem : EntitySystem
                 continue;
             }
 
+            if (_mobState.IsDead(uid))
+            {
+                RemCompDeferred<VictimHuggedComponent>(uid);
+                return;
+            }
+
             RemCompDeferred<VictimHuggedComponent>(uid);
             Spawn(hugged.BurstSpawn, xform.Coordinates);
             EnsureComp<VictimBurstComponent>(uid);


### PR DESCRIPTION
## About the PR
Fixes #1976 

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Chestbursters can no longer burst out of dead marines.
