### PR TITLE
Add auto equip to cm vendors

### DIFF
--- a/Content.Shared/_CM14/Vendors/CMAutomatedVendorComponent.cs
+++ b/Content.Shared/_CM14/Vendors/CMAutomatedVendorComponent.cs
@@ -1,4 +1,5 @@
-﻿using Robust.Shared.GameStates;
+﻿using System.Numerics;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared._CM14.Vendors;
 
@@ -8,4 +9,10 @@ public sealed partial class CMAutomatedVendorComponent : Component
 {
     [DataField, AutoNetworkedField]
     public List<CMVendorSection> Sections = new();
+
+    [DataField, AutoNetworkedField]
+    public Vector2 MinOffset = new(-0.2f, -0.2f);
+
+    [DataField, AutoNetworkedField]
+    public Vector2 MaxOffset = new (0.2f, 0.2f);
 }


### PR DESCRIPTION
## About the PR
Fixes #1987

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Automated vendors will now try to automatically equip items or put them in the user's hands before dropping them on the ground.