### PR TITLE
Fix xeno healing and drone health

### DIFF
--- a/Content.Shared/_CM14/Xenos/Armor/XenoArmorSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Armor/XenoArmorSystem.cs
@@ -68,8 +68,11 @@ public sealed class XenoArmorSystem : EntitySystem
 
         foreach (var type in types)
         {
-            if (args.Damage.DamageDict.TryGetValue(type, out var amount))
+            if (args.Damage.DamageDict.TryGetValue(type, out var amount) &&
+                amount > FixedPoint2.Zero)
+            {
                 args.Damage.DamageDict[type] = amount / resist;
+            }
         }
 
         var newDamage = args.Damage.GetTotal();
@@ -79,8 +82,11 @@ public sealed class XenoArmorSystem : EntitySystem
 
             foreach (var type in types)
             {
-                if (args.Damage.DamageDict.TryGetValue(type, out var amount))
+                if (args.Damage.DamageDict.TryGetValue(type, out var amount) &&
+                    amount > FixedPoint2.Zero)
+                {
                     args.Damage.DamageDict[type] = amount * damageWithArmor / (newDamage * 4);
+                }
             }
         }
     }

--- a/Content.Shared/_CM14/Xenos/Pheromones/SharedXenoPheromonesSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Pheromones/SharedXenoPheromonesSystem.cs
@@ -19,7 +19,6 @@ public abstract class SharedXenoPheromonesSystem : EntitySystem
 {
     [Dependency] private readonly EntityLookupSystem _entityLookup = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeed = default!;
-    [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly MobThresholdSystem _mobThreshold = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
@@ -36,14 +35,12 @@ public abstract class SharedXenoPheromonesSystem : EntitySystem
         .ToArray();
 
     private EntityQuery<DamageableComponent> _damageableQuery;
-    private EntityQuery<MobStateComponent> _mobStateQuery;
 
     public override void Initialize()
     {
         base.Initialize();
 
         _damageableQuery = GetEntityQuery<DamageableComponent>();
-        _mobStateQuery = GetEntityQuery<MobStateComponent>();
 
         SubscribeLocalEvent<XenoPheromonesComponent, XenoPheromonesActionEvent>(OnXenoPheromonesAction);
         SubscribeLocalEvent<XenoPheromonesComponent, XenoPheromonesChosenBuiMessage>(OnXenoPheromonesChosenBui);
@@ -198,12 +195,8 @@ public abstract class SharedXenoPheromonesSystem : EntitySystem
             {
                 if (xeno.OnWeeds)
                 {
-                    if (!_mobStateQuery.TryGetComponent(uid, out var mobState) ||
-                        !_mobState.IsDead(uid, mobState))
-                    {
-                        _xeno.HealDamage(uid, recovery.HealthRegen * recovery.Multiplier);
-                        _xenoPlasma.RegenPlasma(uid, recovery.PlasmaRegen * recovery.Multiplier);
-                    }
+                    _xeno.HealDamage(uid, recovery.HealthRegen * recovery.Multiplier);
+                    _xenoPlasma.RegenPlasma(uid, recovery.PlasmaRegen * recovery.Multiplier);
                 }
 
                 recovery.NextRegenTime = _timing.CurTime + recovery.Delay;

--- a/Content.Shared/_CM14/Xenos/Pheromones/SharedXenoPheromonesSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Pheromones/SharedXenoPheromonesSystem.cs
@@ -194,10 +194,7 @@ public abstract class SharedXenoPheromonesSystem : EntitySystem
             if (_timing.CurTime > recovery.NextRegenTime)
             {
                 if (xeno.OnWeeds)
-                {
-                    _xeno.HealDamage(uid, recovery.HealthRegen * recovery.Multiplier);
                     _xenoPlasma.RegenPlasma(uid, recovery.PlasmaRegen * recovery.Multiplier);
-                }
 
                 recovery.NextRegenTime = _timing.CurTime + recovery.Delay;
             }

--- a/Content.Shared/_CM14/Xenos/Pheromones/XenoRecoveryPheromonesComponent.cs
+++ b/Content.Shared/_CM14/Xenos/Pheromones/XenoRecoveryPheromonesComponent.cs
@@ -23,9 +23,6 @@ public sealed partial class XenoRecoveryPheromonesComponent : Component
     public TimeSpan Delay = TimeSpan.FromSeconds(1);
 
     [DataField]
-    public FixedPoint2 HealthRegen = 0.5;
-
-    [DataField]
     public FixedPoint2 PlasmaRegen = 1.5;
 
     public override bool SessionSpecific => true;

--- a/Content.Shared/_CM14/Xenos/XenoComponent.cs
+++ b/Content.Shared/_CM14/Xenos/XenoComponent.cs
@@ -17,7 +17,19 @@ public sealed partial class XenoComponent : Component
     public Dictionary<EntProtoId, EntityUid> Actions = new();
 
     [DataField, AutoNetworkedField]
-    public FixedPoint2 HealthRegenOnWeeds = 1.25;
+    public FixedPoint2 FlatHealing = 0.5;
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 CritHealMultiplier = 0.33;
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 RestHealMultiplier = 1;
+
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 StandHealingMultiplier = 0.4;
+
+    [DataField, AutoNetworkedField]
+    public float MaxHealthDivisorHeal = 65;
 
     [DataField, AutoNetworkedField]
     public TimeSpan RegenCooldown = TimeSpan.FromSeconds(1);

--- a/Content.Shared/_CM14/Xenos/XenoSystem.cs
+++ b/Content.Shared/_CM14/Xenos/XenoSystem.cs
@@ -2,15 +2,21 @@
 using Content.Shared._CM14.Xenos.Construction;
 using Content.Shared._CM14.Xenos.Evolution;
 using Content.Shared._CM14.Xenos.Hive;
+using Content.Shared._CM14.Xenos.Pheromones;
+using Content.Shared._CM14.Xenos.Rest;
 using Content.Shared.Access.Components;
 using Content.Shared.Actions;
 using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.Standing;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 
 namespace Content.Shared._CM14.Xenos;
 
@@ -19,7 +25,10 @@ public sealed class XenoSystem : EntitySystem
     [Dependency] private readonly SharedActionsSystem _action = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly MobThresholdSystem _mobThresholds = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly IPrototypeManager _prototypes = default!;
+    [Dependency] private readonly StandingStateSystem _standing = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedXenoConstructionSystem _xenoConstruction = default!;
@@ -106,10 +115,35 @@ public sealed class XenoSystem : EntitySystem
         Dirty(xeno, xeno.Comp);
     }
 
+    private FixedPoint2 GetHealAmount(Entity<XenoComponent> xeno)
+    {
+        if (!xeno.Comp.OnWeeds ||
+            !_mobThresholds.TryGetIncapThreshold(xeno, out var threshold))
+        {
+            return FixedPoint2.Zero;
+        }
+
+        FixedPoint2 multiplier;
+        if (_mobState.IsCritical(xeno))
+            multiplier = xeno.Comp.CritHealMultiplier;
+        else if (_standing.IsDown(xeno) || HasComp<XenoRestingComponent>(xeno))
+            multiplier = xeno.Comp.RestHealMultiplier;
+        else
+            multiplier = xeno.Comp.StandHealingMultiplier;
+
+        var passiveHeal = threshold.Value / 65 + xeno.Comp.FlatHealing;
+        var recovery = (CompOrNull<XenoRecoveryPheromonesComponent>(xeno)?.Multiplier ?? 0) / 2;
+        var recoveryHeal = (threshold.Value / 65) * (recovery / 2);
+        return (passiveHeal + recoveryHeal) * multiplier / 2;
+    }
+
     public void HealDamage(Entity<DamageableComponent?> xeno, FixedPoint2 amount)
     {
-        if (!_damageableQuery.Resolve(xeno, ref xeno.Comp, false))
+        if (!_damageableQuery.Resolve(xeno, ref xeno.Comp, false) ||
+            xeno.Comp.Damage.GetTotal() <= FixedPoint2.Zero)
+        {
             return;
+        }
 
         if (_mobStateQuery.TryGetComponent(xeno, out var mobState) &&
             _mobState.IsDead(xeno, mobState))
@@ -118,25 +152,47 @@ public sealed class XenoSystem : EntitySystem
         }
 
         var heal = new DamageSpecifier();
-        foreach (var (type, typeAmount) in xeno.Comp.Damage.DamageDict)
+        var groups = new Dictionary<string, List<string>>();
+        foreach (var group in _prototypes.EnumeratePrototypes<DamageGroupPrototype>())
         {
-            var total = heal.GetTotal();
-            if (typeAmount + total >= amount)
+            foreach (var type in group.DamageTypes)
             {
-                var change = -FixedPoint2.Min(typeAmount, amount - total);
-                if (!heal.DamageDict.TryAdd(type, change))
+                if (xeno.Comp.Damage.DamageDict.TryGetValue(type, out var damage) &&
+                    damage > FixedPoint2.Zero)
                 {
-                    heal.DamageDict[type] += change;
+                    groups.GetOrNew(group.ID).Add(type);
+                }
+            }
+        }
+
+        var typesLeft = new List<string>();
+        foreach (var (_, types) in groups)
+        {
+            var left = amount;
+            FixedPoint2? lastLeft;
+            typesLeft.Clear();
+            typesLeft.AddRange(types);
+
+            while (left > 0)
+            {
+                lastLeft = left;
+
+                for (var i = typesLeft.Count - 1; i >= 0; i--)
+                {
+                    var type = typesLeft[i];
+                    var damage = xeno.Comp.Damage.DamageDict[type];
+                    var existingHeal = -heal.DamageDict.GetValueOrDefault(type);
+                    left += existingHeal;
+                    var toHeal = FixedPoint2.Min(existingHeal + left / (i + 1), damage);
+                    if (damage <= toHeal)
+                        typesLeft.RemoveAt(i);
+
+                    heal.DamageDict[type] = -toHeal;
+                    left -= toHeal;
                 }
 
-                break;
-            }
-            else
-            {
-                if (!heal.DamageDict.TryAdd(type, -typeAmount))
-                {
-                    heal.DamageDict[type] += -typeAmount;
-                }
+                if (lastLeft == left)
+                    break;
             }
         }
 
@@ -162,9 +218,10 @@ public sealed class XenoSystem : EntitySystem
 
             xeno.NextRegenTime = time + xeno.RegenCooldown;
 
-            if (xeno.OnWeeds)
+            var heal = GetHealAmount((uid, xeno));
+            if (heal > FixedPoint2.Zero)
             {
-                HealDamage(uid, xeno.HealthRegenOnWeeds);
+                HealDamage(uid, heal);
                 var ev = new XenoRegenEvent();
                 RaiseLocalEvent(uid, ref ev);
             }

--- a/Content.Shared/_CM14/Xenos/XenoSystem.cs
+++ b/Content.Shared/_CM14/Xenos/XenoSystem.cs
@@ -111,6 +111,12 @@ public sealed class XenoSystem : EntitySystem
         if (!_damageableQuery.Resolve(xeno, ref xeno.Comp, false))
             return;
 
+        if (_mobStateQuery.TryGetComponent(xeno, out var mobState) &&
+            _mobState.IsDead(xeno, mobState))
+        {
+            return;
+        }
+
         var heal = new DamageSpecifier();
         foreach (var (type, typeAmount) in xeno.Comp.Damage.DamageDict)
         {
@@ -155,11 +161,6 @@ public sealed class XenoSystem : EntitySystem
                 continue;
 
             xeno.NextRegenTime = time + xeno.RegenCooldown;
-            if (_mobStateQuery.TryGetComponent(uid, out var mobState) &&
-                _mobState.IsDead(uid, mobState))
-            {
-                continue;
-            }
 
             if (xeno.OnWeeds)
             {

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/drone.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/drone.yml
@@ -17,8 +17,8 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      200: Critical
-      300: Dead
+      500: Critical
+      600: Dead
   - type: Xeno
     actionIds:
     - ActionXenoRest


### PR DESCRIPTION
## About the PR
Fixes #1991
Fixes #2040 
Now does the same amount of healing as 13.
Also fixes the drone having 300 health instead of 600.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
