### PR TITLE
Add xeno hivemind chat, prevent marine and xenos from talking with each other

### DIFF
--- a/Content.Client/_CM14/Chat/CMChatSystem.cs
+++ b/Content.Client/_CM14/Chat/CMChatSystem.cs
@@ -1,0 +1,5 @@
+﻿using Content.Shared._CM14.Chat;
+
+namespace Content.Client._CM14.Chat;
+
+public sealed class CMChatSystem : SharedCMChatSystem;

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using Content.Server._CM14.Chat.Chat;
 using Content.Server.Administration.Logs;
 using Content.Server.Administration.Managers;
 using Content.Server.Chat.Managers;
@@ -14,7 +15,6 @@ using Content.Shared.CCVar;
 using Content.Shared.Chat;
 using Content.Shared.Database;
 using Content.Shared.Ghost;
-using Content.Shared.Humanoid;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Mobs.Systems;
@@ -819,6 +819,9 @@ public sealed partial class ChatSystem : SharedChatSystem
         }
 
         RaiseLocalEvent(new ExpandICChatRecipientstEvent(source, voiceGetRange, recipients));
+
+        var ev = new ChatMessageAfterGetRecipients(recipients);
+        RaiseLocalEvent(source, ref ev);
         return recipients;
     }
 

--- a/Content.Server/_CM14/Chat/Chat/CMChatSystem.cs
+++ b/Content.Server/_CM14/Chat/Chat/CMChatSystem.cs
@@ -1,0 +1,55 @@
+﻿using Content.Shared._CM14.Chat;
+using Content.Shared._CM14.Marines;
+using Content.Shared._CM14.Xenos;
+using Robust.Shared.Player;
+
+namespace Content.Server._CM14.Chat.Chat;
+
+public sealed class CMChatSystem : SharedCMChatSystem
+{
+    private readonly List<ICommonSession> _toRemove = new();
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<MarineComponent, ChatMessageAfterGetRecipients>(OnMarineAfterGetRecipients);
+        SubscribeLocalEvent<XenoComponent, ChatMessageAfterGetRecipients>(OnXenoAfterGetRecipients);
+    }
+
+    private void OnMarineAfterGetRecipients(Entity<MarineComponent> ent, ref ChatMessageAfterGetRecipients args)
+    {
+        _toRemove.Clear();
+
+        foreach (var (session, data) in args.Recipients)
+        {
+            if (data.Observer)
+                continue;
+
+            if (HasComp<XenoComponent>(session.AttachedEntity))
+                _toRemove.Add(session);
+        }
+
+        foreach (var session in _toRemove)
+        {
+            args.Recipients.Remove(session);
+        }
+    }
+
+    private void OnXenoAfterGetRecipients(Entity<XenoComponent> ent, ref ChatMessageAfterGetRecipients args)
+    {
+        _toRemove.Clear();
+
+        foreach (var (session, data) in args.Recipients)
+        {
+            if (data.Observer)
+                continue;
+
+            if (!HasComp<XenoComponent>(session.AttachedEntity))
+                _toRemove.Add(session);
+        }
+
+        foreach (var session in _toRemove)
+        {
+            args.Recipients.Remove(session);
+        }
+    }
+}

--- a/Content.Server/_CM14/Chat/Chat/ChatMessageAfterGetRecipients.cs
+++ b/Content.Server/_CM14/Chat/Chat/ChatMessageAfterGetRecipients.cs
@@ -1,0 +1,7 @@
+﻿using Robust.Shared.Player;
+using static Content.Server.Chat.Systems.ChatSystem;
+
+namespace Content.Server._CM14.Chat.Chat;
+
+[ByRefEvent]
+public readonly record struct ChatMessageAfterGetRecipients(Dictionary<ICommonSession, ICChatRecipientData> Recipients);

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -111,6 +111,7 @@ public abstract class SharedChatSystem : EntitySystem
         if (input.Length == 0)
             return false;
 
+        // TODO CM14 replace all of this with something else when chat code isnt a joke
         if (input.StartsWith(RadioCommonPrefix))
         {
             output = SanitizeMessageCapital(input[1..].TrimStart());

--- a/Content.Shared/_CM14/Chat/ChatGetPrefixEvent.cs
+++ b/Content.Shared/_CM14/Chat/ChatGetPrefixEvent.cs
@@ -1,0 +1,6 @@
+﻿using Content.Shared.Radio;
+
+namespace Content.Shared._CM14.Chat;
+
+[ByRefEvent]
+public record struct ChatGetPrefixEvent(RadioChannelPrototype? Channel);

--- a/Content.Shared/_CM14/Chat/SharedCMChatSystem.cs
+++ b/Content.Shared/_CM14/Chat/SharedCMChatSystem.cs
@@ -1,0 +1,26 @@
+﻿using Content.Shared._CM14.Marines;
+using Content.Shared._CM14.Xenos;
+using Content.Shared.Chat;
+
+namespace Content.Shared._CM14.Chat;
+
+public abstract class SharedCMChatSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<MarineComponent, ChatGetPrefixEvent>(OnMarineGetPrefix);
+        SubscribeLocalEvent<XenoComponent, ChatGetPrefixEvent>(OnXenoGetPrefix);
+    }
+
+    private void OnMarineGetPrefix(Entity<MarineComponent> ent, ref ChatGetPrefixEvent args)
+    {
+        if (args.Channel?.ID == SharedChatSystem.HivemindChannel)
+            args.Channel = null;
+    }
+
+    private void OnXenoGetPrefix(Entity<XenoComponent> ent, ref ChatGetPrefixEvent args)
+    {
+        if (args.Channel?.ID != SharedChatSystem.HivemindChannel)
+            args.Channel = null;
+    }
+}

--- a/Content.Shared/_CM14/Xenos/XenoSystem.cs
+++ b/Content.Shared/_CM14/Xenos/XenoSystem.cs
@@ -7,11 +7,13 @@ using Content.Shared._CM14.Xenos.Pheromones;
 using Content.Shared._CM14.Xenos.Rest;
 using Content.Shared.Access.Components;
 using Content.Shared.Actions;
+using Content.Shared.Chat;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.Radio;
 using Content.Shared.Standing;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
@@ -54,6 +56,7 @@ public sealed class XenoSystem : EntitySystem
         SubscribeLocalEvent<XenoComponent, GetAccessTagsEvent>(OnXenoGetAdditionalAccess);
         SubscribeLocalEvent<XenoComponent, NewXenoEvolvedComponent>(OnNewXenoEvolved);
         SubscribeLocalEvent<XenoComponent, HealthScannerAttemptTargetEvent>(OnXenoHealthScannerAttemptTarget);
+        SubscribeLocalEvent<XenoComponent, GetDefaultRadioChannelEvent>(OnXenoGetDefaultRadioChannel);
 
         SubscribeLocalEvent<XenoWeedsComponent, StartCollideEvent>(OnWeedsStartCollide);
         SubscribeLocalEvent<XenoWeedsComponent, EndCollideEvent>(OnWeedsEndCollide);
@@ -90,6 +93,11 @@ public sealed class XenoSystem : EntitySystem
     {
         args.Popup = "The scanner can't make sense of this creature.";
         args.Cancelled = true;
+    }
+
+    private void OnXenoGetDefaultRadioChannel(Entity<XenoComponent> ent, ref GetDefaultRadioChannelEvent args)
+    {
+        args.Channel = SharedChatSystem.HivemindChannel;
     }
 
     private void OnWeedsStartCollide(Entity<XenoWeedsComponent> ent, ref StartCollideEvent args)

--- a/Resources/Locale/en-US/_CM14/radio-channels.ftl
+++ b/Resources/Locale/en-US/_CM14/radio-channels.ftl
@@ -16,3 +16,4 @@ chat-radio-marine-echo = Echo
 chat-radio-marine-foxtrot = Foxtrot
 
 chat-radio-colony = Colony
+chat-radio-hivemind = Hivemind

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/base_xeno.yml
@@ -147,8 +147,9 @@
     proto: alien
   - type: MovedByPressure
   - type: NoSlip
-  - type: Pullable # TODO CM14 xeno pullable
-  - type: Speech # TODO CM14 alien language
+  - type: Pullable
+  - type: Speech
+    speechVerb: Xeno
   - type: GhostOnMove
     mustBeDead: true
   - type: WhitelistPickup
@@ -172,6 +173,13 @@
     - KnockedDown
     - SlowedDown
   - type: ImmuneToClothingRequiredStepTrigger
+  - type: IntrinsicRadioReceiver
+  - type: IntrinsicRadioTransmitter
+    channels:
+    - Hivemind
+  - type: ActiveRadio
+    channels:
+    - Hivemind
 
 - type: entity
   abstract: true
@@ -277,3 +285,9 @@
     damage: #per second, scales with number of fire 'stacks'
       types:
         Heat: 3
+
+- type: speechVerb
+  id: Xeno
+  name: Xeno
+  speechVerbStrings:
+  - hisses

--- a/Resources/Prototypes/_CM14/radio_channels.yml
+++ b/Resources/Prototypes/_CM14/radio_channels.yml
@@ -108,3 +108,11 @@
   frequency: 1381
   color: "#cf40a6" #todo cm14
   longRange: true
+
+- type: radioChannel
+  id: Hivemind
+  name: chat-radio-hivemind
+  keycode: "h"
+  frequency: 426
+  color: "#8b36a6"
+  longRange: true


### PR DESCRIPTION
## About the PR
Fixes #1226
Fixes #1227
Fixes #1228
Fixes #1229 
Fixes #1151

Couple issues:
- Upstream chat code is garbage so this is a hacky mess.
- Upstream chat code is garbage so the chat selector still shows "Radio" for xenos, but works as hivemind chat,
- Upstream chat code is garbage so xenos can't see garbled messages when marines speak.
- Upstream chat code is garbage so marines can't see garbled messsages when xenos speak.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Add xeno hivemind chat.