### PR TITLE
Fill out standard marine apparel vendor bundle, fix not assigning a squad if no squad spawner is found, rename departments

### DIFF
--- a/Content.Server/_CM14/Rules/CMRuleSystem.cs
+++ b/Content.Server/_CM14/Rules/CMRuleSystem.cs
@@ -343,10 +343,10 @@ public sealed class CMRuleSystem : GameRuleSystem<CMRuleComponent>
             Log.Error($"No valid spawn found for player. Squad: {squadId}, job: {job.ID}");
 
             if (allSpawners.NonSquad.TryGetValue(job.ID, out spawners))
-                return (_random.Pick(spawners), null);
+                return (_random.Pick(spawners), squadEnt);
 
             if (allSpawners.NonSquadFull.TryGetValue(job.ID, out spawners))
-                return (_random.Pick(spawners), null);
+                return (_random.Pick(spawners), squadEnt);
 
             Log.Error($"No valid spawn found for player. Job: {job.ID}");
         }

--- a/Content.Shared/_CM14/Vendors/CMVendorMapToSquadComponent.cs
+++ b/Content.Shared/_CM14/Vendors/CMVendorMapToSquadComponent.cs
@@ -1,0 +1,15 @@
+﻿using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._CM14.Vendors;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(SharedCMAutomatedVendorSystem))]
+public sealed partial class CMVendorMapToSquadComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public EntProtoId? Default;
+
+    [DataField, AutoNetworkedField]
+    public Dictionary<EntProtoId, EntProtoId> Map = new();
+}

--- a/Resources/Changelog/Parts/cl.yml
+++ b/Resources/Changelog/Parts/cl.yml
@@ -1,5 +1,4 @@
 ﻿author: DrSmugleaf
-category: CM
 changes:
 - type: Add
   message: Replaced the pilot officer with the dropship and gunship pilots.

--- a/Resources/Locale/en-US/_CM14/department.ftl
+++ b/Resources/Locale/en-US/_CM14/department.ftl
@@ -11,7 +11,7 @@ department-CMRequisitions = Requisitions
 cm-department-Requisitions-description = Dispense supplies to the marines.
 
 # marines
-department-CMMarine = Marine [ALL]
+department-CMSquad = Marines
 cm-department-Marine-description = They form the main fighting body of the Almayer and are sent planetside to fight all kinds of dangers throughout the Neroid Sector.
 
 # engineering
@@ -19,11 +19,11 @@ department-CMEngineering = Engineering
 cm-department-Engineering-description = Your job is to maintain the ship's engine and keep everything running.
 
 # medical
-department-CMMedical = Medical
+department-CMMedbay = Medbay
 cm-department-Medical-description = Treat all patients that come into medbay. Transfer injured marines from the hanger to medbay.
 
 # auxiliary support
-department-CMAuxiliarySupport = Auxiliary Support
+department-CMAuxiliarySupport = Auxiliary Combat Support
 cm-department-AuxiliarySupport-description = The Auxiliary support personnel are tasked with supporting the marines either by providing support through firepower or other means.
 
 # other

--- a/Resources/Prototypes/_CM14/Access/Groups/medical_access_groups.yml
+++ b/Resources/Prototypes/_CM14/Access/Groups/medical_access_groups.yml
@@ -8,7 +8,7 @@
   - CMAccessChemistry
 
 - type: accessGroup
-  id: CMMedical
+  id: CMMedbay
   tags:
   - CMAccessMedical
   - CMAccessChemistry

--- a/Resources/Prototypes/_CM14/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/_CM14/Entities/Clothing/Hands/gloves.yml
@@ -1,9 +1,8 @@
-# standard
 - type: entity
   parent: ClothingHandsBase
-  id: CMHandsBlack
-  name: black gloves
-  description: A pair of black gloves.
+  id: CMHandsBlackMarine # TODO CM14 armor
+  name: marine combat gloves
+  description: "Standard issue marine tactical gloves. It reads: 'knit by Marine Widows Association'."
   components:
   - type: Sprite
     sprite: _CM14/Objects/Clothing/Hands/Gloves/black.rsi
@@ -15,7 +14,7 @@
   - type: FingerprintMask
 
 - type: entity
-  parent: CMHandsBlack
+  parent: CMHandsBlackMarine
   id: CMHandsBrown
   name: brown gloves
   description: A pair of brown gloves.
@@ -28,7 +27,7 @@
     fiberColor: fibers-brown
 
 - type: entity
-  parent: CMHandsBlack
+  parent: CMHandsBlackMarine
   id: CMHandsLightBrown
   name: light brown gloves
   description: A pair of light brown gloves.
@@ -41,7 +40,7 @@
     fiberColor: fibers-brown
 
 - type: entity
-  parent: CMHandsBlack
+  parent: CMHandsBlackMarine
   id: CMHandsWhite
   name: white gloves
   description: A pair of white gloves.
@@ -54,7 +53,7 @@
     fiberColor: fibers-white
 
 - type: entity
-  parent: CMHandsBlack
+  parent: CMHandsBlackMarine
   id: CMHandsLatex
   name: latex gloves
   description: A pair of latex gloves.
@@ -69,7 +68,7 @@
 
 #insulated
 - type: entity
-  parent: CMHandsBlack
+  parent: CMHandsBlackMarine
   id: CMHandsInsulated
   name: insulated gloves
   description: These gloves will protect the wearer from electric shocks.

--- a/Resources/Prototypes/_CM14/Entities/Clothing/Head/Helmets/uscm_helmets.yml
+++ b/Resources/Prototypes/_CM14/Entities/Clothing/Head/Helmets/uscm_helmets.yml
@@ -2,7 +2,7 @@
 - type: entity
   parent: ClothingHeadBase
   id: ArmorHelmetM10
-  name: M10 Marine Helmet
+  name: M10 Pattern Marine Helmet
   description: A standard M10 Pattern Helmet. The inside label, along with washing information, reads, 'The difference between an open-casket and closed-casket funeral. Wear on head for best results.'. There is a built-in camera on the right side.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_CM14/Entities/Structures/Doors/Airlocks/accesses-almayer.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Doors/Airlocks/accesses-almayer.yml
@@ -117,7 +117,7 @@
   - type: AccessReader
     access: [["CMAccessMedical"]]
   - type: PaintableAirlock
-    department: CMMedical
+    department: CMMedbay
 
 - type: entity
   parent: CMAirlockMedical

--- a/Resources/Prototypes/_CM14/Entities/Structures/Doors/Airlocks/airlocks.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Doors/Airlocks/airlocks.yml
@@ -16,7 +16,7 @@
     - board
   - type: Occluder
   - type: PaintableAirlock
-    department: CMMarine
+    department: CMSquad
 
 - type: entity
   parent: CMAirlock
@@ -46,7 +46,7 @@
   - type: Sprite
     sprite: _CM14/Structures/Doors/Airlocks/medi_door.rsi
   - type: PaintableAirlock
-    department: CMMedical
+    department: CMMedbay
 
 - type: entity
   parent: CMAirlock
@@ -125,7 +125,7 @@
   - type: Sprite
     sprite: _CM14/Structures/Doors/Airlocks/medi_door_glass.rsi
   - type: PaintableAirlock
-    department: CMMedical
+    department: CMMedbay
 
 - type: entity
   parent: CMAirlockGlass

--- a/Resources/Prototypes/_CM14/Entities/Structures/Doors/Double/double_door.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Doors/Double/double_door.yml
@@ -113,7 +113,7 @@
   - type: Sprite
     sprite: _CM14/Structures/Doors/Airlocks/Double/medical_glass.rsi
   - type: PaintableAirlock
-    department: CMMedical
+    department: CMMedbay
 
 - type: entity
   parent: CMDoubleDoorBase
@@ -124,7 +124,7 @@
     sprite: _CM14/Structures/Doors/Airlocks/Double/medical_solid.rsi
   - type: Occluder
   - type: PaintableAirlock
-    department: CMMedical
+    department: CMMedbay
 
 - type: entity
   parent: CMDoubleDoorBase

--- a/Resources/Prototypes/_CM14/Entities/Structures/Doors/cm_door.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Doors/cm_door.yml
@@ -124,7 +124,7 @@
     mode: NoSprite
   - type: PaintableAirlock
     group: Standard
-    department: CMMarine
+    department: CMSquad
   - type: AccessReader
   - type: StaticPrice
     price: 150

--- a/Resources/Prototypes/_CM14/Entities/Structures/Machines/colmartech_bundles.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Machines/colmartech_bundles.yml
@@ -1,0 +1,11 @@
+﻿- type: entity
+  id: CMVendorBundleRiflemanApparel
+  categories:
+  - hideSpawnMenu
+  components:
+  - type: CMVendorBundle
+    bundle:
+    - ArmorHelmetM10
+    - CMVendorHeadsetSquad
+    - CMHandsBlackMarine
+    - CMBootsBlackFilled

--- a/Resources/Prototypes/_CM14/Entities/Structures/Machines/colmartech_mappings.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Machines/colmartech_mappings.yml
@@ -1,0 +1,11 @@
+﻿- type: entity
+  id: CMVendorHeadsetSquad
+  categories:
+  - hideSpawnMenu
+  components:
+  - type: CMVendorMapToSquad
+    map:
+      SquadAlpha: CMHeadsetAlpha
+      SquadBravo: CMHeadsetBravo
+      SquadCharlie: CMHeadsetCharlie
+      SquadDelta: CMHeadsetDelta

--- a/Resources/Prototypes/_CM14/Entities/Structures/Machines/colmartech_vendors.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Machines/colmartech_vendors.yml
@@ -350,25 +350,25 @@
   - type: CMAutomatedVendor
     sections:
     - name: Standard Equipment
-      choices: {CMStandard: 2}
+      choices: { CMStandard: 2 }
       entries:
-      - id: JumpsuitMarine # TODO cm14 this should be uniform, boots, helmet
+      - id: CMVendorBundleRiflemanApparel
       - id: CMMRE
       #- id: CMMap # TODO: Make a map
     - name: Armor
-      choices: {CMArmour: 1}
+      choices: { CMArmour: 1 }
       entries:
       - id: CMArmorM3Light # Light Armour
       - id: CMArmorM3Medium # Medium Armour
       - id: CMArmorM3Heavy # Heavy Armour
     - name: Backpack
-      choices: {CMBackpack: 1}
+      choices: { CMBackpack: 1 }
       entries:
       - id: CMBackpackMarine
       - id: CMSatchelMarine
       #- id: CMShotgunScabbard # TODO: Make a Scabbard
     - name: Belt
-      choices: {CMBelt: 1}
+      choices: { CMBelt: 1 }
       entries:
       - id: CMBeltMarine
     #    CMM276GeneralPistolHolsterRig #TODO: Make this
@@ -380,7 +380,7 @@
       - id: CMBeltUtility
     #    CMM276M40GrenadeRigEmpty #TODO: Make this
     - name: Pouches
-      choices: {CMPouch: 2}
+      choices: { CMPouch: 2 }
       entries:
       - id: CMPouchBayonet
       - id: CMPouchFirstAid
@@ -394,7 +394,7 @@
       - id: CMPouchMagazinePistol
       - id: CMPouchPistol
     - name: Mask
-      choices: {CMMask: 1}
+      choices: { CMMask: 1 }
       entries:
       - id: CMClothingMaskGas
     #    CMHeatAbsorbentCoif #TODO: Make this

--- a/Resources/Prototypes/_CM14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
@@ -6,7 +6,7 @@
   playTimeTracker: CMJobAuxiliarySupportOfficer
   requirements:
   - !type:DepartmentTimeRequirement
-    department: CMMarine
+    department: CMSquad
     time: 18000 # 5 hours
   - !type:DepartmentTimeRequirement
     department: CMRequisitions

--- a/Resources/Prototypes/_CM14/Roles/Jobs/AuxiliarySupport/dropship_crew_chief.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/AuxiliarySupport/dropship_crew_chief.yml
@@ -6,7 +6,7 @@
   playTimeTracker: CMJobDropshipCrewChief
   requirements:
   - !type:DepartmentTimeRequirement
-    department: CMMarine
+    department: CMSquad
     time: 18000 # 5 hours
   - !type:TotalJobsTimeRequirement
     group: CMJobsMedical

--- a/Resources/Prototypes/_CM14/Roles/Jobs/AuxiliarySupport/intel_officer.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/AuxiliarySupport/intel_officer.yml
@@ -6,7 +6,7 @@
   playTimeTracker: CMJobIntelOfficer
   requirements:
   - !type:DepartmentTimeRequirement
-    department: CMMarine
+    department: CMSquad
     time: 18000 # 5 hours
   startingGear: CMGearIntelOfficer
   icon: "CMJobIconIntelOfficer"

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Command/commanding_officer.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Command/commanding_officer.yml
@@ -6,7 +6,7 @@
   playTimeTracker: CMJobCommandingOfficer
   requirements:
   - !type:DepartmentTimeRequirement
-    department: CMMarine
+    department: CMSquad
     time: 54000 # 15 hours
   - !type:TotalJobsTimeRequirement
     group: CMJobsEngineering

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Departments/human_job_groups.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Departments/human_job_groups.yml
@@ -10,8 +10,8 @@
     - CMAuxiliarySupport
     - CMCommand
     - CMEngineering
-    - CMMarine
-    - CMMedical
+    - CMSquad
+    - CMMedbay
     - CMMilitaryPolice
     - CMOther
     - CMRequisitions

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Departments/marine_department.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Departments/marine_department.yml
@@ -1,6 +1,6 @@
 ﻿- type: department
   parent: CMDepartmentBase
-  id: CMMarine
+  id: CMSquad
   description: cm-department-Marine-description
   color: "#DE3A3A"
   roles:

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Departments/medical_department.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Departments/medical_department.yml
@@ -1,6 +1,6 @@
 ﻿- type: department
   parent: CMDepartmentBase
-  id: CMMedical
+  id: CMMedbay
   description: cm-department-Medical-description
   color: "#008160"
   roles:

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/combat_tech.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/combat_tech.yml
@@ -6,7 +6,7 @@
   playTimeTracker: CMJobCombatTech
   requirements:
   - !type:DepartmentTimeRequirement
-    department: CMMarine
+    department: CMSquad
     time: 3600 # 1 hour
   startingGear: CMGearCombatTech
   icon: "CMJobIconCombatTech"

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/fireteam_leader.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/fireteam_leader.yml
@@ -6,7 +6,7 @@
   playTimeTracker: CMJobFireteamLeader
   requirements:
   - !type:DepartmentTimeRequirement
-    department: CMMarine
+    department: CMSquad
     time: 28800 # 8 hours
   startingGear: CMGearFireteamLeader
   icon: "CMJobIconFireteamLeader"
@@ -38,7 +38,7 @@
     shoes: CMBootsBlackFilled
     head: CMArmorHelmetM12
     outerClothing: CMArmorM4
-    gloves: CMHandsBlack
+    gloves: CMHandsBlackMarine
     id: CMDogtagFireteamLeader
     ears: CMHeadsetAlphaTeamLeader
 

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/hospital_corpsman.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/hospital_corpsman.yml
@@ -9,7 +9,7 @@
     group: CMJobsMedical
     time: 3600 # 1 hours
   - !type:DepartmentTimeRequirement
-    department: CMMarine
+    department: CMSquad
     time: 3600 # 1 hour
   startingGear: CMGearHospitalCorpsman
   icon: "CMJobIconHospitalCorpsman"
@@ -39,7 +39,7 @@
     jumpsuit: CMJumpsuitMarineMedic
     back: CMSatchelMarineMedic
     shoes: CMBootsBlackFilled
-    gloves: CMHandsBlack
+    gloves: CMHandsBlackMarine
     eyes: ClothingEyesHudMedical
     head: CMArmorHelmetM10Medic
     outerClothing: CMArmorM3Medium

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/rifleman.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/rifleman.yml
@@ -32,7 +32,7 @@
     shoes: CMBootsBlackFilled
     head: ArmorHelmetM10
     outerClothing: CMArmorM3Medium
-    gloves: CMHandsBlack
+    gloves: CMHandsBlackMarine
     id: CMDogtagRifleman
     ears: CMHeadsetAlpha
 

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/smartgunner.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/smartgunner.yml
@@ -6,7 +6,7 @@
   playTimeTracker: CMJobSmartgunner
   requirements:
     - !type:DepartmentTimeRequirement
-      department: CMMarine
+      department: CMSquad
       time: 18000 # 5 hours
   startingGear: CMGearSmartgunner
   icon: "CMJobIconSmartgunner"
@@ -37,7 +37,7 @@
     shoes: CMBootsBlackFilled
     head: ArmorHelmetM10
     outerClothing: CMArmorM3Medium
-    gloves: CMHandsBlack
+    gloves: CMHandsBlackMarine
     id: CMDogtagSmartgunner
     ears: CMHeadsetAlpha
 

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/squad_leader.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/squad_leader.yml
@@ -6,7 +6,7 @@
   playTimeTracker: CMJobSquadLeader
   requirements:
   - !type:DepartmentTimeRequirement
-    department: CMMarine
+    department: CMSquad
     time: 36000 # 10 hours
   startingGear: CMGearSquadLeader
   icon: "CMJobIconSquadLeader"
@@ -46,7 +46,7 @@
     shoes: CMBootsBlackFilled
     head: CMArmorHelmetM11
     outerClothing: CMArmorM3Medium
-    gloves: CMHandsBlack
+    gloves: CMHandsBlackMarine
     id: CMDogtagSquadLeader
     ears: CMHeadsetAlphaLeader
 

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Marines/weapons_specialist.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Marines/weapons_specialist.yml
@@ -6,7 +6,7 @@
   playTimeTracker: CMJobWeaponsSpecialist
   requirements:
   - !type:DepartmentTimeRequirement
-    department: CMMarine
+    department: CMSquad
     time: 18000 # 5 hours
   startingGear: CMGearWeaponsSpecialist
   icon: "CMJobIconWeaponsSpecialist"
@@ -42,7 +42,7 @@
     shoes: CMBootsBlackFilled
     head: ArmorHelmetM10
     outerClothing: CMArmorM3Medium
-    gloves: CMHandsBlack
+    gloves: CMHandsBlackMarine
     id: CMDogtagWeaponsSpecialist
     ears: CMHeadsetAlpha
 

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Medical/doctor.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Medical/doctor.yml
@@ -14,7 +14,7 @@
   supervisors: cm-job-supervisors-cmo
   canBeAntag: true
   accessGroups:
-  - CMMedical
+  - CMMedbay
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Medical/nurse.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Medical/nurse.yml
@@ -14,7 +14,7 @@
   supervisors: cm-job-supervisors-cmo
   canBeAntag: true
   accessGroups:
-  - CMMedical
+  - CMMedbay
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_CM14/Roles/Jobs/MilitaryPolice/chief_military_police.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/MilitaryPolice/chief_military_police.yml
@@ -46,7 +46,7 @@
     shoes: CMBootsBlackFilled
     head: CMHeadBeretWO
     eyes: ClothingEyesGlassesSecurity # todo cm14 replace with cm ones
-    gloves: CMHandsBlack
+    gloves: CMHandsBlackMarine
     id: CMIDCardChiefMP
     outerClothing: CMArmorM3WO
     ears: CMHeadsetCMP

--- a/Resources/Prototypes/_CM14/Roles/Jobs/MilitaryPolice/military_police.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/MilitaryPolice/military_police.yml
@@ -6,7 +6,7 @@
   playTimeTracker: CMJobMilitaryPolice
   requirements:
   - !type:DepartmentTimeRequirement
-    department: CMMarine
+    department: CMSquad
     time: 36000 # 10 hours
   weight: 5
   startingGear: CMGearMilitaryPolice
@@ -33,7 +33,7 @@
     shoes: CMBootsBlackFilled
     head: CMHeadBeretRed
     eyes: ClothingEyesGlassesSecurity # todo cm14 replace with cm ones
-    gloves: CMHandsBlack
+    gloves: CMHandsBlackMarine
     id: CMIDCardMilitaryPolice
     outerClothing: CMArmorM2MP
     ears: CMHeadsetMPO

--- a/Resources/Prototypes/_CM14/Roles/Jobs/MilitaryPolice/military_warden.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/MilitaryPolice/military_warden.yml
@@ -39,7 +39,7 @@
     shoes: CMBootsBlackFilled
     head: CMHeadCapWarden
     eyes: ClothingEyesGlassesSecurity # todo cm14 replace with cm ones
-    gloves: CMHandsBlack
+    gloves: CMHandsBlackMarine
     id: CMIDCardMilitaryWarden
     outerClothing: CMArmorM3Warden
     ears: CMHeadsetCMP

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Other/senior_enlisted_advisor.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Other/senior_enlisted_advisor.yml
@@ -6,7 +6,7 @@
   playTimeTracker: CMJobSeniorEnlistedAdvisor
   requirements:
   - !type:DepartmentTimeRequirement
-    department: CMMarine
+    department: CMSquad
     time: 54000 # 15 hours
   - !type:TotalJobsTimeRequirement
     group: CMJobsEngineering

--- a/Resources/Prototypes/_CM14/Roles/Jobs/Survivor/survivor.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Survivor/survivor.yml
@@ -6,7 +6,7 @@
   playTimeTracker: CMJobSurvivor
   requirements:
   - !type:DepartmentTimeRequirement
-    department: CMMarine
+    department: CMSquad
     time: 18000 # 5 hours
   - !type:TotalJobsTimeRequirement
     group: CMJobsEngineering


### PR DESCRIPTION
## About the PR
Fixes #2047
Fixes #2053 
Also adds CMVendorMapToSquadComponent

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
