### PR TITLE
Make xenos unable to hit each other, their eggs, weeds, nests and dead things

### DIFF
--- a/Content.Shared/_CM14/Xenos/Egg/XenoEggSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Egg/XenoEggSystem.cs
@@ -232,6 +232,9 @@ public sealed class XenoEggSystem : EntitySystem
         egg.Comp.State = state;
         Dirty(egg);
 
+        if (state == XenoEggState.Opened)
+            RemCompDeferred<XenoFriendlyComponent>(egg);
+
         var ev = new XenoEggStateChangedEvent();
         RaiseLocalEvent(egg, ref ev);
     }

--- a/Content.Shared/_CM14/Xenos/XenoFriendlyComponent.cs
+++ b/Content.Shared/_CM14/Xenos/XenoFriendlyComponent.cs
@@ -1,0 +1,7 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._CM14.Xenos;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(XenoSystem))]
+public sealed partial class XenoFriendlyComponent : Component;

--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/base_xeno.yml
@@ -182,7 +182,7 @@
     - Hivemind
   - type: StandingState
   - type: SlowOnPull
-    multiplier: 0.6
+    multiplier: 0.75
   - type: PullWhitelist
     whitelist:
       components:
@@ -190,6 +190,7 @@
       - XenoEgg
       - Huggable
   - type: BlockPullingDead
+  - type: XenoFriendly
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_CM14/Entities/Structures/Xeno/xeno_egg.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Xeno/xeno_egg.yml
@@ -37,3 +37,4 @@
         damage: 60
       behaviors:
       - !type:BurnBodyBehavior { }
+  - type: XenoFriendly

--- a/Resources/Prototypes/_CM14/Entities/Structures/Xeno/xeno_nest.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Xeno/xeno_nest.yml
@@ -39,3 +39,4 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: XenoNest
+  - type: XenoFriendly

--- a/Resources/Prototypes/_CM14/Entities/Structures/Xeno/xeno_weeds.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Xeno/xeno_weeds.yml
@@ -75,6 +75,7 @@
         weed14: ""
     - 0:
         weed15: ""
+  - type: XenoFriendly
 #  - type: SpeedModifierContacts # TODO CM14 slow down
 #    walkSpeedModifier: 0.5
 #    sprintSpeedModifier: 0.5
@@ -205,6 +206,7 @@
     base: weedwall
     mode: Corners
   - type: XenoNestSurface
+  - type: XenoFriendly
 
 - type: edgeSpreader
   id: XenoWeeds


### PR DESCRIPTION
## About the PR
Fixes #1167

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Xenos are now unable to hit each other, their eggs, weeds, nests and dead things.