### PR TITLE
Fix xeno actions sometimes starting out of order

### DIFF
--- a/Content.Client/Actions/ActionsSystem.cs
+++ b/Content.Client/Actions/ActionsSystem.cs
@@ -315,6 +315,12 @@ namespace Content.Client.Actions
             AssignSlot?.Invoke(assignments);
         }
 
+        public void SetAssignments(List<SlotAssignment> actions)
+        {
+            ClearAssignments?.Invoke();
+            AssignSlot?.Invoke(actions);
+        }
+
         public record struct SlotAssignment(byte Hotbar, byte Slot, EntityUid ActionId);
     }
 }

--- a/Content.Client/_CM14/Xenos/Action/XenoActionSystem.cs
+++ b/Content.Client/_CM14/Xenos/Action/XenoActionSystem.cs
@@ -1,0 +1,68 @@
+﻿using System.Linq;
+using Content.Client.Actions;
+using Content.Shared._CM14.Xenos;
+using Content.Shared.Actions;
+using Robust.Client.Player;
+using static Content.Client.Actions.ActionsSystem;
+
+namespace Content.Client._CM14.Xenos.Action;
+
+public sealed class XenoActionSystem : EntitySystem
+{
+    [Dependency] private readonly ActionsSystem _actions = default!;
+    [Dependency] private readonly IPlayerManager _player = default!;
+
+    private EntityUid? _sortedEnt;
+
+    public override void Shutdown()
+    {
+        _sortedEnt = null;
+    }
+
+    public override void Update(float frameTime)
+    {
+        if (_player.LocalEntity is not { } player)
+            return;
+
+        if (_sortedEnt == player)
+            return;
+
+        _sortedEnt = null;
+
+        if (!TryComp(player, out XenoComponent? xeno))
+            return;
+
+        foreach (var (_, actionId) in xeno.Actions)
+        {
+            if (!actionId.IsValid())
+                return;
+        }
+
+        _sortedEnt = player;
+
+        var actions = new List<Entity<BaseActionComponent>>();
+        foreach (var action in _actions.GetActions(player))
+        {
+            actions.Add(action);
+        }
+
+        var xenoActions = xeno.Actions.Values.ToList();
+        actions.Sort((a, b) =>
+        {
+            var aXeno = xenoActions.FindIndex(e => e == a.Owner);
+            var bXeno = xenoActions.FindIndex(e => e == b.Owner);
+            if (aXeno != -1 && bXeno != -1)
+                return aXeno - bXeno;
+
+            return ActionComparer((a, a), (b, b));
+        });
+
+        var assignments = new List<SlotAssignment>();
+        for (var i = 0; i < actions.Count; i++)
+        {
+            assignments.Add(new SlotAssignment(0, (byte) i, actions[i]));
+        }
+
+        _actions.SetAssignments(assignments);
+    }
+}

--- a/Content.Shared/_CM14/Xenos/XenoComponent.cs
+++ b/Content.Shared/_CM14/Xenos/XenoComponent.cs
@@ -14,7 +14,7 @@ public sealed partial class XenoComponent : Component
     [DataField, AutoNetworkedField]
     public List<EntProtoId> ActionIds = new();
 
-    [DataField]
+    [DataField, AutoNetworkedField]
     public Dictionary<EntProtoId, EntityUid> Actions = new();
 
     [DataField, AutoNetworkedField]


### PR DESCRIPTION
## About the PR
Fixes https://github.com/CM-14/CM-14/issues/2038

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed xeno actions sometimes starting out of order.
