### PR TITLE
M92 tweaks, grenades land exactly where clicked and have a short delay before exploding

### DIFF
--- a/Content.Client/UserInterface/Systems/Hands/HandsUIController.cs
+++ b/Content.Client/UserInterface/Systems/Hands/HandsUIController.cs
@@ -459,7 +459,7 @@ public sealed class HandsUIController : UIController, IOnStateEntered<GameplaySt
                 var delay = _useDelay.GetLastEndingDelay((hand.Entity.Value, useDelay));
 
                 hand.CooldownDisplay.Visible = true;
-                hand.CooldownDisplay.FromTime(delay.StartTime, delay.EndTime);
+                hand.CooldownDisplay.FromTime(delay!.StartTime, delay.EndTime);
             }
         }
     }

--- a/Content.Server/_CM14/Trigger/CMTriggerSystem.cs
+++ b/Content.Server/_CM14/Trigger/CMTriggerSystem.cs
@@ -1,0 +1,22 @@
+﻿using Content.Server.Explosion.EntitySystems;
+using Content.Shared.Weapons.Ranged.Events;
+
+namespace Content.Server._CM14.Trigger;
+
+public sealed class CMTriggerSystem : EntitySystem
+{
+    [Dependency] private readonly TriggerSystem _trigger = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<OnShootTriggerAmmoTimerComponent, AmmoShotEvent>(OnTriggerTimerAmmoShot);
+    }
+
+    private void OnTriggerTimerAmmoShot(Entity<OnShootTriggerAmmoTimerComponent> ent, ref AmmoShotEvent args)
+    {
+        foreach (var projectile in args.FiredProjectiles)
+        {
+            _trigger.HandleTimerTrigger(projectile, null, ent.Comp.Delay, ent.Comp.BeepInterval, ent.Comp.InitialBeepDelay, ent.Comp.Sound);
+        }
+    }
+}

--- a/Content.Server/_CM14/Trigger/OnShootTriggerAmmoTimerComponent.cs
+++ b/Content.Server/_CM14/Trigger/OnShootTriggerAmmoTimerComponent.cs
@@ -1,0 +1,20 @@
+﻿using Robust.Shared.Audio;
+
+namespace Content.Server._CM14.Trigger;
+
+[RegisterComponent]
+[Access(typeof(CMTriggerSystem))]
+public sealed partial class OnShootTriggerAmmoTimerComponent : Component
+{
+    [DataField]
+    public float Delay;
+
+    [DataField]
+    public float BeepInterval;
+
+    [DataField]
+    public float? InitialBeepDelay;
+
+    [DataField]
+    public SoundSpecifier? Sound;
+}

--- a/Content.Shared/Timing/UseDelaySystem.cs
+++ b/Content.Shared/Timing/UseDelaySystem.cs
@@ -123,12 +123,12 @@ public sealed class UseDelaySystem : EntitySystem
     /// <summary>
     /// Returns info for the delay that will end farthest in the future.
     /// </summary>
-    public UseDelayInfo GetLastEndingDelay(Entity<UseDelayComponent> ent)
+    public UseDelayInfo? GetLastEndingDelay(Entity<UseDelayComponent> ent)
     {
-        var last = ent.Comp.Delays[DefaultId];
+        UseDelayInfo? last = null;
         foreach (var entry in ent.Comp.Delays)
         {
-            if (entry.Value.EndTime > last.EndTime)
+            if (last == null || entry.Value.EndTime > last.EndTime)
                 last = entry.Value;
         }
         return last;

--- a/Content.Shared/Weapons/Ranged/Components/GunRequiresWieldComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GunRequiresWieldComponent.cs
@@ -6,8 +6,13 @@ namespace Content.Shared.Weapons.Ranged.Components;
 /// <summary>
 /// Indicates that this gun requires wielding to be useable.
 /// </summary>
-[RegisterComponent, NetworkedComponent, Access(typeof(WieldableSystem))]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(WieldableSystem))]
 public sealed partial class GunRequiresWieldComponent : Component
 {
+    [DataField, AutoNetworkedField]
+    public TimeSpan LastPopup;
 
+    [DataField, AutoNetworkedField]
+    public TimeSpan PopupCooldown = TimeSpan.FromSeconds(1);
 }

--- a/Content.Shared/Weapons/Ranged/Events/ShotAttemptedEvent.cs
+++ b/Content.Shared/Weapons/Ranged/Events/ShotAttemptedEvent.cs
@@ -1,3 +1,5 @@
+using Content.Shared.Weapons.Ranged.Components;
+
 namespace Content.Shared.Weapons.Ranged.Events;
 
 /// <summary>
@@ -15,7 +17,7 @@ public record struct ShotAttemptedEvent
     /// <summary>
     /// The gun being shot.
     /// </summary>
-    public EntityUid Used;
+    public Entity<GunComponent> Used;
 
     public bool Cancelled { get; private set; }
 

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -239,7 +239,7 @@ public abstract partial class SharedGunSystem : EntitySystem
         var prevention = new ShotAttemptedEvent
         {
             User = user,
-            Used = gunUid
+            Used = (gunUid, gun)
         };
         RaiseLocalEvent(gunUid, ref prevention);
         if (prevention.Cancelled)

--- a/Content.Shared/_CM14/Weapons/Ranged/AmmoFixedDistanceComponent.cs
+++ b/Content.Shared/_CM14/Weapons/Ranged/AmmoFixedDistanceComponent.cs
@@ -1,0 +1,7 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._CM14.Weapons.Ranged;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(CMGunSystem))]
+public sealed partial class AmmoFixedDistanceComponent : Component;

--- a/Content.Shared/_CM14/Weapons/Ranged/CMGunSystem.cs
+++ b/Content.Shared/_CM14/Weapons/Ranged/CMGunSystem.cs
@@ -1,0 +1,114 @@
+﻿using System.Numerics;
+using Content.Shared.Timing;
+using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Events;
+using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Events;
+using Robust.Shared.Physics.Systems;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._CM14.Weapons.Ranged;
+
+public sealed class CMGunSystem : EntitySystem
+{
+    [Dependency] private readonly SharedBroadphaseSystem _broadphase = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly UseDelaySystem _useDelay = default!;
+
+    private EntityQuery<PhysicsComponent> _physicsQuery;
+
+    public override void Initialize()
+    {
+        _physicsQuery = GetEntityQuery<PhysicsComponent>();
+
+        SubscribeLocalEvent<AmmoFixedDistanceComponent, AmmoShotEvent>(OnAmmoFixedDistanceShot);
+
+        SubscribeLocalEvent<ProjectileFixedDistanceComponent, StartCollideEvent>(OnProjectileStop);
+        SubscribeLocalEvent<ProjectileFixedDistanceComponent, ComponentRemove>(OnProjectileStop);
+        SubscribeLocalEvent<ProjectileFixedDistanceComponent, PhysicsSleepEvent>(OnProjectileStop);
+
+        SubscribeLocalEvent<GunShowUseDelayComponent, GunShotEvent>(OnShowUseDelayShot);
+    }
+
+    private void OnAmmoFixedDistanceShot(Entity<AmmoFixedDistanceComponent> ent, ref AmmoShotEvent args)
+    {
+        if (!TryComp(ent, out GunComponent? gun) ||
+            gun.ShootCoordinates is not { } target)
+        {
+            return;
+        }
+
+        var from = _transform.GetMapCoordinates(ent);
+        var to = target.ToMap(EntityManager, _transform);
+        if (from.MapId != to.MapId)
+            return;
+
+        var direction = to.Position - from.Position;
+        if (direction == Vector2.Zero)
+            return;
+
+        var time = _timing.CurTime;
+        var normalized = direction.Normalized();
+        foreach (var projectile in args.FiredProjectiles)
+        {
+            if (!_physicsQuery.TryComp(projectile, out var physics))
+                continue;
+
+            var impulse = normalized * gun.ProjectileSpeedModified * physics.Mass;
+            _physics.SetLinearVelocity(projectile, Vector2.Zero, body: physics);
+            _physics.ApplyLinearImpulse(projectile, impulse, body: physics);
+            _physics.SetBodyStatus(projectile, physics, BodyStatus.InAir);
+
+            var comp = EnsureComp<ProjectileFixedDistanceComponent>(projectile);
+            comp.FlyEndTime = time + TimeSpan.FromSeconds(direction.Length() / gun.ProjectileSpeedModified);
+        }
+    }
+
+    private void OnProjectileStop<T>(Entity<ProjectileFixedDistanceComponent> ent, ref T args)
+    {
+        StopProjectile(ent);
+    }
+
+    private void OnShowUseDelayShot(Entity<GunShowUseDelayComponent> ent, ref GunShotEvent args)
+    {
+        if (!TryComp(ent, out GunComponent? gun))
+            return;
+
+        var remaining = gun.NextFire - _timing.CurTime;
+        if (remaining <= TimeSpan.Zero)
+            return;
+
+        var useDelay = EnsureComp<UseDelayComponent>(ent);
+        _useDelay.SetLength((ent, useDelay), remaining, ent.Comp.DelayId);
+        _useDelay.TryResetDelay((ent, useDelay), false, ent.Comp.DelayId);
+    }
+
+    private void StopProjectile(Entity<ProjectileFixedDistanceComponent> projectile)
+    {
+        if (!_physicsQuery.TryGetComponent(projectile, out var physics))
+            return;
+
+        _physics.SetLinearVelocity(projectile, Vector2.Zero, body: physics);
+        _physics.SetBodyStatus(projectile, physics, BodyStatus.OnGround);
+
+        if (physics.Awake)
+            _broadphase.RegenerateContacts(projectile, physics);
+    }
+
+    public override void Update(float frameTime)
+    {
+        var time = _timing.CurTime;
+        var query = EntityQueryEnumerator<ProjectileFixedDistanceComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (time < comp.FlyEndTime)
+                continue;
+
+            RemCompDeferred<ProjectileFixedDistanceComponent>(uid);
+        }
+    }
+}

--- a/Content.Shared/_CM14/Weapons/Ranged/GunShowUseDelayComponent.cs
+++ b/Content.Shared/_CM14/Weapons/Ranged/GunShowUseDelayComponent.cs
@@ -1,0 +1,11 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._CM14.Weapons.Ranged;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(CMGunSystem))]
+public sealed partial class GunShowUseDelayComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public string DelayId = "CMGunShowUseDelay";
+}

--- a/Content.Shared/_CM14/Weapons/Ranged/ProjectileFixedDistanceComponent.cs
+++ b/Content.Shared/_CM14/Weapons/Ranged/ProjectileFixedDistanceComponent.cs
@@ -1,0 +1,11 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._CM14.Weapons.Ranged;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(CMGunSystem))]
+public sealed partial class ProjectileFixedDistanceComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public TimeSpan FlyEndTime;
+}

--- a/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Guns/Launchers/uscm_launchers.yml
+++ b/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Guns/Launchers/uscm_launchers.yml
@@ -38,3 +38,4 @@
   - type: AmmoFixedDistance
   - type: Wieldable
   - type: GunRequiresWield
+  - type: GunShowUseDelay

--- a/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Guns/Launchers/uscm_launchers.yml
+++ b/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Guns/Launchers/uscm_launchers.yml
@@ -7,23 +7,34 @@
   - type: Sprite
     sprite: _CM14/Objects/Weapons/Guns/GrenadeLaunchers/m92.rsi
     layers:
-      - state: icon
-        map: ["enum.GunVisualLayers.Base"]
+    - state: icon
+      map: [ "enum.GunVisualLayers.Base" ]
   - type: Clothing
     sprite: _CM14/Objects/Weapons/Guns/GrenadeLaunchers/m92.rsi
   - type: AmmoCounter
   - type: Gun
-    fireRate: 2
+    fireRate: 0.23
     selectedMode: SemiAuto
     availableModes:
-      - SemiAuto
+    - SemiAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/grenade_launcher.ogg
   - type: BallisticAmmoProvider
     whitelist:
       tags:
-        - LauncherCompatibleGrenade
+      - LauncherCompatibleGrenade
     capacity: 5
     proto: M40HEDP
     soundInsert:
       path: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg
+  - type: OnShootTriggerAmmoTimer
+    delay: 1
+    beepInterval: 2 # 2 beeps total (at 0 and 2)
+    initialBeepDelay: 0
+    beepSound:
+      path: "/Audio/Effects/beep1.ogg"
+      params:
+        volume: 5
+  - type: AmmoFixedDistance
+  - type: Wieldable
+  - type: GunRequiresWield

--- a/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -7,6 +7,7 @@
   components:
   - type: ExplosionResistance
     damageCoefficient: 0
+  - type: AmmoFixedDistance
 
 - type: entity
   name: M40 HEDP grenade
@@ -34,9 +35,7 @@
     tags:
     - Grenade
     - LauncherCompatibleGrenade
-  - type: CartridgeAmmo
-    proto: HEDPProjectile
-    deleteOnSpawn: true
+  - type: Ammo
 
 - type: entity
   parent: CMGrenadeBase
@@ -59,9 +58,7 @@
     tags:
     - Grenade
     - LauncherCompatibleGrenade
-  - type: CartridgeAmmo
-    proto: SmokeProjectile
-    deleteOnSpawn: true
+  - type: Ammo
 
 - type: entity
   parent: CMGrenadeBase
@@ -85,7 +82,5 @@
     tags:
     - Grenade
 #    - LauncherCompatibleGrenade
-#  - type: CartridgeAmmo
-#    proto: HEFAProjectile
-#    deleteOnSpawn: true
+#  - type: Ammo
 # Need to rework how cluster is handled


### PR DESCRIPTION
## About the PR
## Media
https://github.com/CM-14/CM-14/assets/10968691/c3c396ef-9f83-4942-a8f2-493ba3215a0d

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: The M92 grenade launcher's grenades now land exactly where the user clicks and have a short delay before exploding.