### PR TITLE
Let marines cut their way out of a xeno while devoured

### DIFF
--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -65,7 +65,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         if (!TryGetWeapon(entity, out var weaponUid, out var weapon))
             return;
 
-        if (!CombatMode.IsInCombatMode(entity) || !Blocker.CanAttack(entity))
+        if (!CombatMode.IsInCombatMode(entity) || !Blocker.CanAttack(entity, weapon: (weaponUid, weapon)))
         {
             weapon.Attacking = false;
             return;

--- a/Content.Shared/_CM14/Xenos/Devour/UsableWhileDevouredComponent.cs
+++ b/Content.Shared/_CM14/Xenos/Devour/UsableWhileDevouredComponent.cs
@@ -1,0 +1,7 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._CM14.Xenos.Devour;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(XenoDevourSystem))]
+public sealed partial class UsableWhileDevouredComponent : Component;

--- a/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Melee/knife.yml
@@ -31,6 +31,7 @@
     sprite: _CM14/Objects/Weapons/Melee/m5_bayonet.rsi
   - type: DisarmMalus
     malus: 0.225
+  - type: CanUseWhileDevoured
 
 - type: entity
   name: M11 throwing knife


### PR DESCRIPTION
## About the PR
Includes the changes from https://github.com/space-wizards/space-station-14/pull/28040

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- add: Marines can now cut their way out of a xeno while devoured.