### PR TITLE
pistol magazine insertion sound fix

### DIFF
--- a/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Guns/Pistols/uscm_pistols.yml
+++ b/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Guns/Pistols/uscm_pistols.yml
@@ -81,6 +81,8 @@
     slots:
       gun_magazine:
         name: Magazine
+        #insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg #TODO cm14 pistol sounds
+        #ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
         priority: 2
         whitelist:
           tags:

--- a/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Guns/Pistols/uscm_pistols.yml
+++ b/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Guns/Pistols/uscm_pistols.yml
@@ -116,6 +116,8 @@
     slots:
       gun_magazine:
         name: Magazine
+        #insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg #TODO cm14 pistol sounds
+        #ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
         priority: 2
         whitelist:
           tags:

--- a/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Guns/Pistols/uscm_pistols.yml
+++ b/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Guns/Pistols/uscm_pistols.yml
@@ -81,8 +81,6 @@
     slots:
       gun_magazine:
         name: Magazine
-        insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
-        ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
         priority: 2
         whitelist:
           tags:
@@ -116,8 +114,6 @@
     slots:
       gun_magazine:
         name: Magazine
-        insertSound: /Audio/Weapons/Guns/MagIn/ltrifle_magin.ogg
-        ejectSound: /Audio/Weapons/Guns/MagOut/ltrifle_magout.ogg
         priority: 2
         whitelist:
           tags:


### PR DESCRIPTION
## About the PR
Pistol clips inherit pistol magazine sounds from their base parent, then define rifle magazine sounds

If this was actually intended to be the sound used by all pistols, then it should still be removed from the individual pistol prototypes and put on their base parent instead


## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase