### PR TITLE
Put shells back in ammobox

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/shotgun.yml
@@ -21,6 +21,7 @@
       whitelist:
         tags:
         - ShellShotgun
+        - CMShellShotgun
       capacity: 16
 
 # Shotgun Shells


### PR DESCRIPTION
Added missing CMShell tag to whitelist
Fixes  #2304
