### PR TITLE
Fix shotgun box empty sprite state

### DIFF
--- a/Content.Client/_CM14/Weapons/Ranged/CMAmmoBoxSystem.cs
+++ b/Content.Client/_CM14/Weapons/Ranged/CMAmmoBoxSystem.cs
@@ -38,6 +38,6 @@ public sealed class CMAmmoBoxSystem : EntitySystem
     private void UpdateAppearance(Entity<CMAmmoBoxComponent, SpriteComponent, AppearanceComponent> box)
     {
         _appearance.TryGetData(box, AmmoVisuals.AmmoCount, out int count, box);
-        box.Comp2.LayerSetVisible(box.Comp1, count > 0);
+        box.Comp2.LayerSetVisible(box.Comp1.AmmoLayer, count > 0);
     }
 }

--- a/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/shotgun.yml
+++ b/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/shotgun.yml
@@ -10,6 +10,7 @@
   - type: Sprite
     sprite: _CM14/Objects/Weapons/Guns/Ammunition/Boxes/shotgun_boxes.rsi
   - type: CMAmmoBox
+  - type: Appearance
 
 - type: entity
   parent: CMBoxShotgunBase


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Shotgun box empty sprite was not getting set correctly.
Fixes #2302

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

https://github.com/CM-14/CM-14/assets/10494922/a7bd4bff-6e82-4480-8782-c41e0c4078c8


## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- fix: Fixed shotgun shell box not changing sprite when empty.
