### PR TITLE
Pouch visualisation fixed, vial and bayonet pouches fixed.

### DIFF
--- a/Resources/Prototypes/_CM14/Entities/Clothing/pouches.yml
+++ b/Resources/Prototypes/_CM14/Entities/Clothing/pouches.yml
@@ -131,6 +131,8 @@
   - type: ItemSlots
   - type: CMHolster
   - type: CMItemSlots
+    cooldown: 1
+    cooldownPopup: You need to wait before drawing another knife!
     count: 5
     slot:
       name: Knife

--- a/Resources/Prototypes/_CM14/Entities/Clothing/pouches.yml
+++ b/Resources/Prototypes/_CM14/Entities/Clothing/pouches.yml
@@ -737,7 +737,7 @@
     - 0,0,15,1 #8 slots
 
 - type: entity
-  parent: [CMPouchOpenClosed, CMPouchStorage]
+  parent: [CMPouchClosed, CMPouchStorage]
   id: CMPouchSling
   name: sling strap # TODO CM14 implement this
   description: Keeps a single item attached to a strap.

--- a/Resources/Prototypes/_CM14/Entities/Clothing/pouches.yml
+++ b/Resources/Prototypes/_CM14/Entities/Clothing/pouches.yml
@@ -45,7 +45,7 @@
     layers:
     - state: icon
     - state: closed
-      map: [ "closedLayer" ]
+      map: [ "closed" ]
   - type: GenericVisualizer
     visuals:
       enum.SharedBagOpenVisuals.BagState:
@@ -65,6 +65,7 @@
       map: [ "closedLayer" ]
     - state: open
       map: [ "openLayer" ]
+  - type: Appearance
   - type: GenericVisualizer
     visuals:
       enum.SharedBagOpenVisuals.BagState:
@@ -76,7 +77,7 @@
           Closed: { visible: true }
 
 - type: entity
-  parent: [CMPouchStorage, CMPouchOpenClosed]
+  parent: [CMPouchOpenClosed, CMPouchStorage]
   id: CMPouchGeneral
   name: light general pouch
   description: A general-purpose pouch used to carry a small item, or two tiny ones.
@@ -120,7 +121,7 @@
 # m39ap pouch
 
 - type: entity
-  parent: [CMPouchStorage, CMPouchOpenClosed]
+  parent: [CMPouchOpenClosed]
   id: CMPouchBayonet
   name: bayonet sheath
   description: Knife to meet you!
@@ -136,9 +137,10 @@
       whitelist:
         tags:
         - Knife
+        - ThrowingKnife
 
 - type: entity
-  parent: [CMPouchStorage, CMPouchOpenClosed]
+  parent: [CMPouchOpenClosed, CMPouchStorage]
   id: CMPouchSurvival
   name: survival pouch
   description: A pouch given to colonists in the event of an emergency.
@@ -182,7 +184,7 @@
       - Welder
 
 - type: entity
-  parent: [CMPouchStorage, CMPouchOpenClosed]
+  parent: [CMPouchOpenClosed, CMPouchStorage]
   id: CMPouchFirstAid
   name: first-aid pouch
   description: It contains, by default, autoinjectors. But it may also hold ointments, bandages, and pill packets.
@@ -247,7 +249,7 @@
   - type: CMItemSlots
 
 - type: entity
-  parent: [CMPouchStorage, CMPouchClosed]
+  parent: [CMPouchOpenClosed, CMPouchStorage]
   id: CMPouchCommand
   name: command pouch
   description: A specialized, sturdy pouch issued to Commanding Officers. Can hold their sidearm, the command tablet and a set of binoculars.
@@ -264,7 +266,7 @@
   - type: FixedItemSizeStorage
 
 - type: entity
-  parent: [CMPouchStorage, CMPouchOpenClosed]
+  parent: [CMPouchOpenClosed, CMPouchStorage]
   id: CMPouchMagazine
   name: magazine pouch
   description: It can carry magazines.
@@ -351,7 +353,7 @@
 #    - 0,0,13,1 #7 slots
 
 - type: entity
-  parent: [CMPouchStorage, CMPouchOpenClosed]
+  parent: [CMPouchOpenClosed, CMPouchStorage]
   id: CMPouchExplosive
   name: explosive pouch
   description: It can carry grenades, plastic explosives, mine boxes, and other explosives.
@@ -368,7 +370,7 @@
   - type: FixedItemSizeStorage
 
 - type: entity
-  parent: [CMPouchStorage, CMPouchOpenClosed]
+  parent: [CMPouchOpenClosed, CMPouchStorage]
   id: CMPouchMedical
   name: medical pouch
   description: It can carry small medical supplies.
@@ -443,7 +445,7 @@
   description: A heavy pouch containing everything one needs to get themselves back on their feet. Quite the selection. Somehow, the whole pouch manages to look classified, you feel like you're going to get court-marshalled for even looking at it.
 
 - type: entity
-  parent: [CMPouchStorage, CMPouchOpenClosed]
+  parent: [CMPouchOpenClosed, CMPouchStorage]
   id: CMPouchFirstResponder
   name: first responder pouch
   description: A pouch designed for carrying supplies to assist medical personnel and quickly respond to injuries on the battlefield without immediately treating them. Can hold supplies such as roller beds, stasis bags, and health analysers.
@@ -474,7 +476,7 @@
   - type: FixedItemSizeStorage
 
 - type: entity
-  parent: [CMPouchStorage, CMPouchOpenClosed]
+  parent: [CMPouchOpenClosed, CMPouchStorage]
   id: CMPouchVial
   name: vial pouch
   description: A pouch for carrying glass vials.
@@ -488,9 +490,10 @@
     whitelist:
       components:
       - FitsInDispenser
+  - type: FixedItemSizeStorage
 
 - type: entity
-  parent: [CMPouchStorage, CMPouchOpenClosed]
+  parent: [CMPouchOpenClosed, CMPouchStorage]
   id: CMPouchChem
   name: chemist pouch
   description: A pouch for carrying glass beakers.
@@ -507,10 +510,8 @@
       - Bottle
   - type: FixedItemSizeStorage
 
-# TODO CM14 vial pouch
-
 - type: entity
-  parent: [CMPouchStorage, CMPouchOpenClosed]
+  parent: [CMPouchOpenClosed, CMPouchStorage]
   id: CMPouchAutoinjector
   name: auto-injector pouch
   description: A pouch specifically for auto-injectors.
@@ -526,7 +527,7 @@
   - type: FixedItemSizeStorage
 
 - type: entity
-  parent: [CMPouchStorage, CMPouchOpenClosed]
+  parent: [CMPouchOpenClosed, CMPouchStorage]
   id: CMPouchSyringe
   name: syringe pouch
   description: It can carry syringes.
@@ -542,7 +543,7 @@
   - type: FixedItemSizeStorage
 
 - type: entity
-  parent: [CMPouchStorage, CMPouchOpenClosed]
+  parent: [CMPouchOpenClosed, CMPouchStorage]
   id: CMPouchMedkit
   name: medical kit pouch
   description: It's specifically made to hold medical items.
@@ -581,7 +582,7 @@
   - type: FixedItemSizeStorage
 
 - type: entity
-  parent: [CMPouchStorage, CMPouchOpenClosed]
+  parent: [CMPouchOpenClosed, CMPouchStorage]
   id: CMPouchDocument
   name: large document pouch
   description: It can contain papers, folders, disks, technical manuals, and clipboards.
@@ -629,7 +630,7 @@
         - Flare
 
 - type: entity
-  parent: [CMPouchStorage, CMPouchOpenClosed]
+  parent: [CMPouchOpenClosed, CMPouchStorage]
   id: CMPouchRadio
   name: radio pouch
   description: It can contain two handheld radios.
@@ -645,7 +646,7 @@
   - type: FixedItemSizeStorage
 
 - type: entity
-  parent: [CMPouchStorage, CMPouchOpenClosed]
+  parent: [CMPouchOpenClosed, CMPouchStorage]
   id: CMPouchElectronics
   name: electronics pouch
   description: It is designed to hold most electronics, power cells and circuit boards.
@@ -666,7 +667,7 @@
   - type: FixedItemSizeStorage
 
 - type: entity
-  parent: [CMPouchStorage, CMPouchOpenClosed]
+  parent: [CMPouchOpenClosed, CMPouchStorage]
   id: CMPouchConstruction
   name: construction pouch
   description: It's designed to hold construction materials - glass/metal sheets, metal rods, barbed wire, cable coil, and empty sandbags. It also has two hooks for an entrenching tool and light replacer.
@@ -691,7 +692,7 @@
   - type: FixedItemSizeStorage
 
 - type: entity
-  parent: [CMPouchStorage, CMPouchOpenClosed]
+  parent: [CMPouchOpenClosed, CMPouchStorage]
   id: CMPouchTools
   name: tools pouch
   description: It's designed to hold maintenance tools - screwdriver, wrench, cable coil, etc. It also has a hook for an entrenching tool or light replacer.
@@ -734,7 +735,7 @@
     - 0,0,15,1 #8 slots
 
 - type: entity
-  parent: [CMPouchStorage, CMPouchClosed]
+  parent: [CMPouchOpenClosed, CMPouchStorage]
   id: CMPouchSling
   name: sling strap # TODO CM14 implement this
   description: Keeps a single item attached to a strap.

--- a/Resources/Prototypes/_CM14/Entities/Clothing/pouches.yml
+++ b/Resources/Prototypes/_CM14/Entities/Clothing/pouches.yml
@@ -45,7 +45,7 @@
     layers:
     - state: icon
     - state: closed
-      map: [ "closed" ]
+      map: [ "closedLayer" ]
   - type: GenericVisualizer
     visuals:
       enum.SharedBagOpenVisuals.BagState:
@@ -65,7 +65,6 @@
       map: [ "closedLayer" ]
     - state: open
       map: [ "openLayer" ]
-  - type: Appearance
   - type: GenericVisualizer
     visuals:
       enum.SharedBagOpenVisuals.BagState:
@@ -251,7 +250,7 @@
   - type: CMItemSlots
 
 - type: entity
-  parent: [CMPouchOpenClosed, CMPouchStorage]
+  parent: [CMPouchClosed, CMPouchStorage]
   id: CMPouchCommand
   name: command pouch
   description: A specialized, sturdy pouch issued to Commanding Officers. Can hold their sidearm, the command tablet and a set of binoculars.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
You can now put throwing knives back into the bayonet pouch they spawn in. It also no longer tries to open its unused storage UI.
The vial pouch now properly uses slots.
All pouches properly change their sprites when opened or closed.

## Technical details
Something about how the visualisation of open and closed containers is handled means that `CMPouchOpenClosed` needs to be before `CMPouchStorage`.
The bayonet pouch tries to use both `CMHolster` and the normal storage system. For now I made it use just `CMHolster`, like the knife belt. Although it might be better to change `CMHolster` so it works *with* the storage system instead of in addition to it? Not sure.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Vial pouches now use slots.
- fix: Bayonet pouches can now actually hold the knives they spawn with and the same delay as with the knife belt is applied when drawing from them.
- fix: All pouches properly display their closed/open sprites.
