### PR TITLE
Makes the HPR full-auto, fixes the attempted quick equip on wielding pulse rifles.

### DIFF
--- a/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Guns/Rifles/uscm_rifles.yml
+++ b/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Guns/Rifles/uscm_rifles.yml
@@ -7,7 +7,7 @@
   - type: Item
     size: Large
   - type: Clothing
-    quickEquip: true
+    quickEquip: false
     slots:
     - suitStorage
     - Back
@@ -88,9 +88,9 @@
   - type: Clothing
     sprite: _CM14/Objects/Weapons/Guns/Rifles/m41ae2.rsi
   - type: Gun
-    selectedMode: SemiAuto
+    selectedMode: FullAuto
     availableModes:
-    - SemiAuto # TODO CM14 burst with greatly increased angle unless mounted
+    - FullAuto # TODO CM14 burst with greatly increased angle unless mounted
     soundGunshot:
       collection: CMM41AShoot
   - type: GunWieldBonus


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
The HPR now fires in full- instead of semi-auto.
The mk2 and the HPR no longer snap to your armour for a brief moment when you wield them.

## Why / Balance
#2307

## Media
![thing](https://github.com/CM-14/CM-14/assets/84070966/7cb07c83-4187-40b3-b446-1749eaec3272)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: The HPR fires in full-auto again.
- fix: The mk2 and the HPR no longer try to snap to your armour when being wielded.
