### PR TITLE
Makes the shotgun-pumping hotkey rebindable

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -129,7 +129,7 @@ namespace Content.Client.Input
         private static void CMFunctions(IInputContextContainer contexts)
         {
             var human = contexts.GetContext("human");
-            human.AddFunction(CMKeyFunctions.CMPumpShotgun);
+            human.AddFunction(CMKeyFunctions.CMUniqueAction);
             human.AddFunction(CMKeyFunctions.CMHolsterPrimary);
             human.AddFunction(CMKeyFunctions.CMHolsterSecondary);
             human.AddFunction(CMKeyFunctions.CMHolsterTertiary);

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -153,6 +153,7 @@ namespace Content.Client.Options.UI.Tabs
             }
 
             AddHeader("ui-options-header-cm");
+            AddButton(CMKeyFunctions.CMUniqueAction);
             AddButton(CMKeyFunctions.CMHolsterPrimary);
             AddButton(CMKeyFunctions.CMHolsterSecondary);
             AddButton(CMKeyFunctions.CMHolsterTertiary);

--- a/Content.Client/_CM14/Weapons/Ranged/PumpActionSystem.cs
+++ b/Content.Client/_CM14/Weapons/Ranged/PumpActionSystem.cs
@@ -14,10 +14,10 @@ public sealed class PumpActionSystem : SharedPumpActionSystem
 
     protected override void OnExamined(Entity<PumpActionComponent> ent, ref ExaminedEvent args)
     {
-        if (!_input.TryGetKeyBinding(CMKeyFunctions.CMPumpShotgun, out var bind))
+        if (!_input.TryGetKeyBinding(CMKeyFunctions.CMUniqueAction, out var bind))
             return;
 
-        args.PushMarkup($"[bold]Press [color=cyan]{bind.GetKeyString()}[/color] to pump before shooting.[/bold]", 1);
+        args.PushMarkup($"[bold]Press your [color=cyan]unique action[/color] keybind to pump before shooting.[/bold]", 1);
     }
 
     protected override void OnAttemptShoot(Entity<PumpActionComponent> ent, ref AttemptShootEvent args)
@@ -26,7 +26,7 @@ public sealed class PumpActionSystem : SharedPumpActionSystem
 
         if (!ent.Comp.Pumped)
         {
-            var message = _input.TryGetKeyBinding(CMKeyFunctions.CMPumpShotgun, out var bind)
+            var message = _input.TryGetKeyBinding(CMKeyFunctions.CMUniqueAction, out var bind)
                 ? $"You need to pump the gun with {bind.GetKeyString()} first!"
                 : "You need to pump the gun first!";
             _popup.PopupClient(message, args.User, args.User);

--- a/Content.Client/_CM14/Weapons/Ranged/PumpActionSystem.cs
+++ b/Content.Client/_CM14/Weapons/Ranged/PumpActionSystem.cs
@@ -17,7 +17,7 @@ public sealed class PumpActionSystem : SharedPumpActionSystem
         if (!_input.TryGetKeyBinding(CMKeyFunctions.CMUniqueAction, out var bind))
             return;
 
-        args.PushMarkup($"[bold]Press your [color=cyan]unique action[/color] keybind to pump before shooting.[/bold]", 1);
+        args.PushMarkup($"[bold]Press your [color=cyan]unique action[/color] keybind (Spacebar by default) to pump before shooting.[/bold]", 1);
     }
 
     protected override void OnAttemptShoot(Entity<PumpActionComponent> ent, ref AttemptShootEvent args)

--- a/Content.Shared/_CM14/Input/CMKeyFunctions.cs
+++ b/Content.Shared/_CM14/Input/CMKeyFunctions.cs
@@ -14,7 +14,7 @@ public sealed class CMKeyFunctions
     public static readonly BoundKeyFunction MappingCancelEraseDecal = "MappingCancelEraseDecal";
     public static readonly BoundKeyFunction MappingOpenContextMenu = "MappingOpenContextMenu";
 
-    public static readonly BoundKeyFunction CMPumpShotgun = "CMPumpShotgun";
+    public static readonly BoundKeyFunction CMUniqueAction = "CMUniqueAction";
     public static readonly BoundKeyFunction CMHolsterPrimary = "CMHolsterPrimary";
     public static readonly BoundKeyFunction CMHolsterSecondary = "CMHolsterSecondary";
     public static readonly BoundKeyFunction CMHolsterTertiary = "CMHolsterTertiary";

--- a/Content.Shared/_CM14/Weapons/Ranged/SharedPumpActionSystem.cs
+++ b/Content.Shared/_CM14/Weapons/Ranged/SharedPumpActionSystem.cs
@@ -42,7 +42,7 @@ public abstract class SharedPumpActionSystem : EntitySystem
     protected virtual void OnExamined(Entity<PumpActionComponent> ent, ref ExaminedEvent args)
     {
         // TODO CM14 the server has no idea what this keybind is supposed to be for the client
-        args.PushMarkup("[bold]Press your [color=cyan]unique action[/color] keybind to pump before shooting.[/bold]", 1);
+        args.PushMarkup("[bold]Press your [color=cyan]unique action[/color] keybind (Spacebar by default) to pump before shooting.[/bold]", 1);
     }
 
     private void OnGetVerbs(Entity<PumpActionComponent> ent, ref GetVerbsEvent<InteractionVerb> args)

--- a/Content.Shared/_CM14/Weapons/Ranged/SharedPumpActionSystem.cs
+++ b/Content.Shared/_CM14/Weapons/Ranged/SharedPumpActionSystem.cs
@@ -25,7 +25,7 @@ public abstract class SharedPumpActionSystem : EntitySystem
         SubscribeLocalEvent<PumpActionComponent, GunShotEvent>(OnGunShot);
 
         CommandBinds.Builder
-            .Bind(CMKeyFunctions.CMPumpShotgun,
+            .Bind(CMKeyFunctions.CMUniqueAction,
                 InputCmdHandler.FromDelegate(session =>
                 {
                     if (session?.AttachedEntity is { } entity)
@@ -42,7 +42,7 @@ public abstract class SharedPumpActionSystem : EntitySystem
     protected virtual void OnExamined(Entity<PumpActionComponent> ent, ref ExaminedEvent args)
     {
         // TODO CM14 the server has no idea what this keybind is supposed to be for the client
-        args.PushMarkup("[bold]Press [color=cyan]Space[/color] to pump before shooting.[/bold]", 1);
+        args.PushMarkup("[bold]Press your [color=cyan]unique action[/color] keybind to pump before shooting.[/bold]", 1);
     }
 
     private void OnGetVerbs(Entity<PumpActionComponent> ent, ref GetVerbsEvent<InteractionVerb> args)

--- a/Resources/Locale/en-US/_CM14/escape-menu/options-menu.ftl
+++ b/Resources/Locale/en-US/_CM14/escape-menu/options-menu.ftl
@@ -1,5 +1,6 @@
 ﻿ui-options-header-cm = Colonial Marines 14
 
+ui-options-function-cm-unique-action = Unique action
 ui-options-function-cm-holster-primary = Unholster
 ui-options-function-cm-holster-secondary = Unholster secondary
 ui-options-function-cm-holster-tertiary = Unholster tertiary

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -574,7 +574,7 @@ binds:
   type: State
   key: MouseRight
   canFocus: true
-- function: CMPumpShotgun
+- function: CMUniqueAction
   type: State
   key: Space
 - function: CMHolsterPrimary


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
As the title says, this makes it possible to rebind the hotkey for pumping a shotgun. Bound to the spacebar by default, as before.

## Technical details
`CMKeyFunctions.CMPumpShotgun` renamed to `CMKeyFunctions.CMUniqueAction`, so we can reuse the hotkey for other weapons with similar mechanics. Making a separate keybind for each and every one of them seems wasteful. If it's decided the original name should stay, I'll just update the PR to bring it back.

## Media
![thing](https://github.com/CM-14/CM-14/assets/84070966/9761a638-fe0d-4bb8-ba46-1fee22269614)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
`CMKeyFunctions.CMPumpShotgun` renamed to `CMKeyFunctions.CMUniqueAction`.

**Changelog**
:cl:
- add: The hotkey for pumping the shotgun has been added to the keybinds menu.
