### PR TITLE
Fix Ordnance Technician description

### DIFF
--- a/Resources/Prototypes/_CM14/Roles/Jobs/Engineering/ordnance_tech.yml
+++ b/Resources/Prototypes/_CM14/Roles/Jobs/Engineering/ordnance_tech.yml
@@ -2,7 +2,7 @@
   id: CMOrdnanceTech
   parent: CMJobBase
   name: cm-job-name-ordnance-tech
-  description: cm-job-description-ordnance-Tech
+  description: cm-job-description-ordnance-tech
   playTimeTracker: CMJobOrdnanceTech
   requirements:
   - !type:TotalJobsTimeRequirement


### PR DESCRIPTION
![image](https://github.com/CM-14/CM-14/assets/135308300/35c962e8-7b43-417c-97d9-307a6900125d)

I asked myself "What's the easiest PR I could do?" This is a one character change. Fixes the localization line for the Ordnance Technician being incorrect. 