### PR TITLE
Removes ammonia from rotting corpses and perishables

### DIFF
--- a/Content.Server/Atmos/Rotting/RottingSystem.cs
+++ b/Content.Server/Atmos/Rotting/RottingSystem.cs
@@ -1,11 +1,9 @@
 using Content.Server.Atmos.EntitySystems;
-using Content.Server.Body.Components;
 using Content.Server.Temperature.Components;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Rotting;
 using Content.Shared.Damage;
 using Robust.Server.Containers;
-using Robust.Shared.Physics.Components;
 using Robust.Shared.Timing;
 
 namespace Content.Server.Atmos.Rotting;
@@ -13,7 +11,6 @@ namespace Content.Server.Atmos.Rotting;
 public sealed class RottingSystem : SharedRottingSystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
     [Dependency] private readonly ContainerSystem _container = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
 
@@ -21,22 +18,7 @@ public sealed class RottingSystem : SharedRottingSystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<RottingComponent, BeingGibbedEvent>(OnGibbed);
-
         SubscribeLocalEvent<TemperatureComponent, IsRottingEvent>(OnTempIsRotting);
-    }
-
-    private void OnGibbed(EntityUid uid, RottingComponent component, BeingGibbedEvent args)
-    {
-        if (!TryComp<PhysicsComponent>(uid, out var physics))
-            return;
-
-        if (!TryComp<PerishableComponent>(uid, out var perishable))
-            return;
-
-        var molsToDump = perishable.MolsPerSecondPerUnitMass * physics.FixturesMass * (float) component.TotalRotTime.TotalSeconds;
-        var tileMix = _atmosphere.GetTileMixture(uid, excite: true);
-        tileMix?.AdjustMoles(Gas.Ammonia, molsToDump);
     }
 
     private void OnTempIsRotting(EntityUid uid, TemperatureComponent component, ref IsRottingEvent args)
@@ -120,13 +102,6 @@ public sealed class RottingSystem : SharedRottingSystem
                 }
             }
 
-            if (!TryComp<PhysicsComponent>(uid, out var physics))
-                continue;
-            // We need a way to get the mass of the mob alone without armor etc in the future
-            // or just remove the mass mechanics altogether because they aren't good.
-            var molRate = perishable.MolsPerSecondPerUnitMass * (float) rotting.RotUpdateRate.TotalSeconds;
-            var tileMix = _atmosphere.GetTileMixture(uid, excite: true);
-            tileMix?.AdjustMoles(Gas.Ammonia, molRate * physics.FixturesMass);
         }
     }
 }

--- a/Content.Shared/Atmos/Rotting/PerishableComponent.cs
+++ b/Content.Shared/Atmos/Rotting/PerishableComponent.cs
@@ -39,6 +39,7 @@ public sealed partial class PerishableComponent : Component
 
     /// <summary>
     /// How many moles of gas released per second, per unit of mass.
+    /// CM14 default to 0 to prevent any organic species (including base SS14) from generating gas
     /// </summary>
     [DataField]
     public float MolsPerSecondPerUnitMass = 0;

--- a/Content.Shared/Atmos/Rotting/PerishableComponent.cs
+++ b/Content.Shared/Atmos/Rotting/PerishableComponent.cs
@@ -37,6 +37,12 @@ public sealed partial class PerishableComponent : Component
     [DataField]
     public TimeSpan PerishUpdateRate = TimeSpan.FromSeconds(5);
 
+    /// <summary>
+    /// How many moles of gas released per second, per unit of mass.
+    /// </summary>
+    [DataField]
+    public float MolsPerSecondPerUnitMass = 0;
+
     [DataField, AutoNetworkedField]
     public int Stage;
 }

--- a/Content.Shared/Atmos/Rotting/PerishableComponent.cs
+++ b/Content.Shared/Atmos/Rotting/PerishableComponent.cs
@@ -37,12 +37,6 @@ public sealed partial class PerishableComponent : Component
     [DataField]
     public TimeSpan PerishUpdateRate = TimeSpan.FromSeconds(5);
 
-    /// <summary>
-    /// How many moles of gas released per second, per unit of mass.
-    /// </summary>
-    [DataField]
-    public float MolsPerSecondPerUnitMass = 0.0025f;
-
     [DataField, AutoNetworkedField]
     public int Stage;
 }


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Corpses and perishable no longer produce ammonia.

## Why / Balance
Fixes #2355 - atmos takes a backseat in CM14, the purple stank is distracting.

## Technical details
Ammonia itself is still in-game, set mol generation to 0 in PerishableComponent.cs.

## Media
![image](https://github.com/CM-14/CM-14/assets/20566341/2b10e229-530a-41c7-9a75-6f7fdf64faa1)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame

## Breaking changes
Hopefully none since ammonia gas is still in-game, just not generated by rot.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Bodies and perishables no longer produce ammonia
