### PR TITLE
Fixes material drops from destroyed constructible objects, makes the construction steps identical to those in CM13

### DIFF
--- a/Resources/Prototypes/_CM14/Entities/Structures/Doors/Airlocks/assembly.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Doors/Airlocks/assembly.yml
@@ -19,7 +19,7 @@
           electronics: { state: as_1 }
           wired: { state: as_2 }
           airlock: { state: as_3 }
-          glassAssembly { state: as_g0 }
-          glassElectronics { state: as_g1 }
-          glassWired { state: as_g2 }
-          glassAirlock { state: as_g3 }
+          glassAssembly: { state: as_g0 }
+          glassElectronics: { state: as_g1 }
+          glassWired: { state: as_g2 }
+          glassAirlock: { state: as_g3 }

--- a/Resources/Prototypes/_CM14/Entities/Structures/Doors/Airlocks/assembly.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Doors/Airlocks/assembly.yml
@@ -10,3 +10,16 @@
   - type: Construction
     graph: CMAirlock
     node: assembly
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.ConstructionVisuals.Key:
+        enum.ConstructionVisuals.Layer:
+          assembly: { state: as_0 }
+          electronics: { state: as_1 }
+          wired: { state: as_2 }
+          airlock: { state: as_3 }
+          glassAssembly { state: as_g0 }
+          glassElectronics { state: as_g1 }
+          glassWired { state: as_g2 }
+          glassAirlock { state: as_g3 }

--- a/Resources/Prototypes/_CM14/Entities/Structures/Doors/Windoors/assembly.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Doors/Windoors/assembly.yml
@@ -40,11 +40,11 @@
           CMShardGlass:
             min: 1
             max: 1
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          CableApcStack1:
-            min: 1
-            max: 1
+#      - !type:SpawnEntitiesBehavior
+#        spawn:
+#          CableApcStack1: #TODO CM14 APC cable
+#            min: 1
+#            max: 1
   - type: Construction
     graph: CMWindoor
     node: assembly

--- a/Resources/Prototypes/_CM14/Entities/Structures/Doors/Windoors/assembly.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Doors/Windoors/assembly.yml
@@ -37,9 +37,14 @@
         acts: ["Destruction"]
       - !type:SpawnEntitiesBehavior
         spawn:
-          CMSheetMetal1:
+          CMShardGlass:
             min: 1
-            max: 3
+            max: 1
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          CableApcStack1:
+            min: 1
+            max: 1
   - type: Construction
     graph: CMWindoor
     node: assembly
@@ -62,9 +67,14 @@
         acts: ["Destruction"]
       - !type:SpawnEntitiesBehavior
         spawn:
-          SheetPlasteel1: #todo cm14 look up
+          CMShardGlass:
             min: 1
-            max: 2
+            max: 1
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          CableApcStack1:
+            min: 1
+            max: 1
   - type: Construction
     graph: CMWindoor
     node: assemblySecure

--- a/Resources/Prototypes/_CM14/Entities/Structures/Doors/Windoors/assembly.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Doors/Windoors/assembly.yml
@@ -70,11 +70,11 @@
           CMShardGlass:
             min: 1
             max: 1
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          CableApcStack1:
-            min: 1
-            max: 1
+#      - !type:SpawnEntitiesBehavior
+#        spawn:
+#          CableApcStack1: #TODO CM14 APC cable
+#            min: 1
+#            max: 1
   - type: Construction
     graph: CMWindoor
     node: assemblySecure

--- a/Resources/Prototypes/_CM14/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Doors/Windoors/windoor.yml
@@ -24,9 +24,6 @@
     - state: panel_open
       map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       visible: false
-  - type: Anchorable
-  - type: Pullable
-  - type: Rotatable
   - type: Construction
     graph: CMWindoor
     node: windoor
@@ -62,9 +59,6 @@
     - state: panel_open
       map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       visible: false
-  - type: Anchorable
-  - type: Pullable
-  - type: Rotatable
   - type: Construction
     graph: CMWindoor
     node: windoorSecure

--- a/Resources/Prototypes/_CM14/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Doors/Windoors/windoor.yml
@@ -24,6 +24,9 @@
     - state: panel_open
       map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       visible: false
+  - type: Anchorable
+  - type: Pullable
+  - type: Rotatable
   - type: Construction
     graph: CMWindoor
     node: windoor
@@ -59,6 +62,9 @@
     - state: panel_open
       map: [ "enum.WiresVisualLayers.MaintenancePanel" ]
       visible: false
+  - type: Anchorable
+  - type: Pullable
+  - type: Rotatable
   - type: Construction
     graph: CMWindoor
     node: windoorSecure

--- a/Resources/Prototypes/_CM14/Entities/Structures/Walls/barricade_metal.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Walls/barricade_metal.yml
@@ -62,8 +62,8 @@
       - !type:SpawnEntitiesBehavior
         spawn:
           CMSheetMetal1:
-            min: 3
-            max: 3
+            min: 2
+            max: 2
       - !type:PlaySoundBehavior
         sound:
           collection: MetalBreak

--- a/Resources/Prototypes/_CM14/Entities/Structures/Walls/girder.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Walls/girder.yml
@@ -56,8 +56,8 @@
         damage: 200
       behaviors:
       - !type:DoActsBehavior
-            acts: [ "Destruction" ]
-      - trigger:
+        acts: [ "Destruction" ]
+    - trigger:
         !type:DamageTrigger
         damage: 50
       behaviors:

--- a/Resources/Prototypes/_CM14/Entities/Structures/Walls/girder.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Walls/girder.yml
@@ -12,6 +12,28 @@
   - type: Construction
     graph: CMGirder
     node: girder
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 200
+      behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+    - trigger:
+        !type:DamageTrigger
+        damage: 50
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          CMSheetMetal1:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
 
 - type: entity
   parent: CMGirder
@@ -24,30 +46,33 @@
   - type: Icon
     sprite: _CM14/Structures/Walls/girder.rsi
     state: girder
-  - type: Construction
-    graph: CMGirder
-    node: reinforcedGirder
+  ##- type: Construction
+  ##  graph: CMGirder
+  ##  node: reinforcedGirder
   - type: Destructible
     thresholds:
-      - trigger:
-          !type:DamageTrigger
-          damage: 200
-        behaviors:
-          - !type:DoActsBehavior
+    - trigger:
+        !type:DamageTrigger
+        damage: 200
+      behaviors:
+      - !type:DoActsBehavior
             acts: [ "Destruction" ]
       - trigger:
-          !type:DamageTrigger
-          damage: 50
-        behaviors:
-          - !type:SpawnEntitiesBehavior
-            spawn:
-              CMSheetMetal1:
-                min: 1
-                max: 1
-              SheetPlasteel1:
-                min: 1
-                max: 1
-          - !type:DoActsBehavior
-            acts: [ "Destruction" ]
+        !type:DamageTrigger
+        damage: 50
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+        spawn:
+          CMSheetMetal1:
+            min: 1
+            max: 1
+          CMSheetPlasteel1:
+            min: 1
+            max: 1
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
   - type: StaticPrice
     price: 66

--- a/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/materials/glass.yml
+++ b/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/materials/glass.yml
@@ -3,20 +3,20 @@
   id: CMGlass
   start: start
   graph:
-    - node: start
-      edges:
-        - to: SheetGlassReinforced
-          completed:
-            - !type:SetStackCount
-              amount: 1
-          steps:
-            - material: CMGlass
-              amount: 1
-            - material: MetalRod
-              amount: 1
+  - node: start
+    edges:
+    - to: SheetGlassReinforced
+      completed:
+      - !type:SetStackCount
+        amount: 1
+      steps:
+        - material: CMGlass
+          amount: 1
+        - material: CMRodMetal
+          amount: 1
 
-    - node: SheetGlass
-      entity: CMSheetGlass
+  - node: SheetGlass
+    entity: CMSheetGlass
 
-    - node: SheetGlassReinforced
-      entity: CMSheetGlassReinforced
+  - node: SheetGlassReinforced
+    entity: CMSheetGlassReinforced

--- a/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/structures/airlock.yml
+++ b/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/structures/airlock.yml
@@ -32,8 +32,8 @@
           sprite: "Objects/Misc/module.rsi"
           state: "door_electronics"
         doAfter: 4
-    
-    - to: glassAssembly
+
+    - to: glassAssembly 
       steps:
       - material: CMGlass
         amount: 5
@@ -47,7 +47,7 @@
       - !type:DeleteEntity {}
       steps:
       - tool: Prying
-          doAfter: 2
+        doAfter: 2
 
   - node: electronics
     entity: CMAirlockAssembly
@@ -208,7 +208,7 @@
     doNotReplaceInheritingEntities: true
     actions:
     - !type:SetWiresPanelSecurity
-        wiresAccessible: true
+      wiresAccessible: true
     - !type:AppearanceChange
     edges:
     - to: glassAssembly

--- a/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/structures/airlock.yml
+++ b/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/structures/airlock.yml
@@ -11,7 +11,7 @@
         value: false
       steps:
       - material: CMSteel
-        amount: 4
+        amount: 5
         doAfter: 2
 
   - node: assembly
@@ -19,29 +19,7 @@
     actions:
     - !type:SnapToGrid {}
     - !type:SetAnchor {}
-    edges:
-    - to: wired
-      conditions:
-      - !type:EntityAnchored {}
-      steps:
-      - material: Cable
-        amount: 5
-        doAfter: 2.5
-    - to: start
-      conditions:
-      - !type:EntityAnchored
-        anchored: false
-      completed:
-      - !type:SpawnPrototype
-        prototype: CMSheetMetal1
-        amount: 4
-      - !type:DeleteEntity {}
-      steps:
-      - tool: Welding
-        doAfter: 3
-
-  - node: wired
-    entity: CMAirlockAssembly
+    - !type:AppearanceChange
     edges:
     - to: electronics
       conditions:
@@ -53,32 +31,61 @@
         icon:
           sprite: "Objects/Misc/module.rsi"
           state: "door_electronics"
-        doAfter: 3
-    - to: assembly
+        doAfter: 4
+    
+    - to: glassAssembly
+      steps:
+      - material: CMGlass
+        amount: 5
+        doAfter: 2
+        
+    - to: start
       completed:
       - !type:SpawnPrototype
-        prototype: CableApcStack1
+        prototype: CMSheetMetal1
         amount: 5
+      - !type:DeleteEntity {}
       steps:
-      - tool: Cutting
-        doAfter: 2.5
+      - tool: Prying
+          doAfter: 2
 
   - node: electronics
+    entity: CMAirlockAssembly
+    actions:
+    - !type:AppearanceChange
+    edges:
+    - to: wired
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+        - material: Cable
+          amount: 1
+          doAfter: 4
+    
+    - to: assembly
+      conditions:
+      - !type:EntityAnchored {}
+      completed:
+      - !type:EmptyAllContainers {}
+      steps:
+      - tool: Prying
+        doAfter: 5
+
+  - node: wired
+    entity: CMAirlockAssembly
+    actions:
+    - !type:AppearanceChange
     edges:
     - to: airlock
       conditions:
       - !type:EntityAnchored {}
       steps:
       - tool: Screwing
-        doAfter: 2.5
-    - to: glassElectronics
-      conditions:
-      - !type:EntityAnchored {}
-      steps:
-      - material: CMGlassReinforced
-        amount: 1
-        doAfter: 2
-    - to: wired
+        doAfter: 4
+      - tool: Welding
+        doAfter: 4
+    
+    - to: assembly
       conditions:
       - !type:EntityAnchored {}
       completed:
@@ -87,44 +94,18 @@
       - tool: Prying
         doAfter: 5
 
-  - node: glassElectronics
-    entity: CMAirlockAssembly
-    edges:
-    - to: glassAirlock
-      conditions:
-      - !type:EntityAnchored {}
-      steps:
-      - material: CMGlassReinforced
-        amount: 1
-        doAfter: 2
-      - tool: Screwing
-        doAfter: 2.5
-    - to: wired
-      conditions:
-      - !type:EntityAnchored {}
-      completed:
-      - !type:EmptyAllContainers {}
-      - !type:SpawnPrototype
-        prototype: CMSheetGlassReinforced1
-        amount: 1
-      steps:
-      - tool: Prying
-        doAfter: 5
-
-## Standard airlock
   - node: airlock
     entity: CMAirlock
     doNotReplaceInheritingEntities: true
     actions:
     - !type:SetWiresPanelSecurity
       wiresAccessible: true
+    - !type:AppearanceChange
     edges:
-    - to: wired
+    - to: assembly
       conditions:
       - !type:EntityAnchored {}
       - !type:DoorWelded {}
-      - !type:DoorBolted
-        value: false
       - !type:WirePanel {}
       - !type:AllWiresCut
       completed:
@@ -133,26 +114,111 @@
       - tool: Prying
         doAfter: 5
 
-## Glass airlock
+    ## Glass
+  - node: glassAssembly
+    entity: CMAirlockAssembly
+    actions:
+    - !type:SnapToGrid {}
+    - !type:SetAnchor {}
+    - !type:AppearanceChange
+    edges:
+    - to: glassElectronics
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - tag: DoorElectronics
+        store: board
+        name: "door electronics circuit board"
+        icon:
+          sprite: "Objects/Misc/module.rsi"
+          state: "door_electronics"
+        doAfter: 4
+        
+    - to: start
+      completed:
+      - !type:SpawnPrototype
+        prototype: CMSheetMetal1
+        amount: 5
+      - !type:SpawnPrototype
+        prototype: CMSheetGlass1
+        amount: 5
+      - !type:DeleteEntity {}
+      steps:
+      - tool: Prying
+        doAfter: 2
+        
+    - to: assembly
+      conditions:
+      - !type:EntityAnchored {}
+      completed:
+      - !type:SpawnPrototype
+        prototype: CMSheetGlass1
+        amount: 5
+      steps:
+      - tool: Screwing
+        doAfter: 2
+
+  - node: glassElectronics
+    entity: CMAirlockAssembly
+    actions:
+    - !type:AppearanceChange
+    edges:
+    - to: glassWired
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - material: Cable
+        amount: 1
+        doAfter: 4
+        
+    - to: glassAssembly
+      conditions:
+      - !type:EntityAnchored {}
+      completed:
+      - !type:EmptyAllContainers {}
+      steps:
+      - tool: Prying
+        doAfter: 5
+
+  - node: glassWired
+    entity: CMAirlockAssembly
+    actions:
+    - !type:AppearanceChange
+    edges:
+    - to: glassAirlock
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - tool: Screwing
+        doAfter: 4
+      - tool: Welding
+        doAfter: 4
+        
+    - to: glassAssembly
+      conditions:
+      - !type:EntityAnchored {}
+      completed:
+      - !type:EmptyAllContainers {}
+      steps:
+      - tool: Prying
+        doAfter: 5
+
   - node: glassAirlock
     entity: CMAirlockGlass
     doNotReplaceInheritingEntities: true
     actions:
     - !type:SetWiresPanelSecurity
-      wiresAccessible: true
+        wiresAccessible: true
+    - !type:AppearanceChange
     edges:
-    - to: glassElectronics
+    - to: glassAssembly
       conditions:
       - !type:EntityAnchored {}
       - !type:DoorWelded {}
-      - !type:DoorBolted
-        value: false
       - !type:WirePanel {}
       - !type:AllWiresCut
       completed:
-      - !type:SpawnPrototype
-        prototype: CMSheetGlassReinforced1
-        amount: 1
+      - !type:EmptyAllContainers {}
       steps:
       - tool: Prying
-        doAfter: 2
+        doAfter: 5

--- a/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/structures/barricade_metal.yml
+++ b/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/structures/barricade_metal.yml
@@ -12,24 +12,27 @@
       - !type:SnapToGrid
       steps:
       - material: CMSteel
-        amount: 3
-        doAfter: 6
+        amount: 4
+        doAfter: 2
 
   - node: nodeMetal
     entity: CMBarricadeMetal
     edges:
     - to: start
       completed:
-        - !type:SpawnPrototype
-          prototype: CMSheetMetal1
-          amount: 2
-        - !type:DeleteEntity
+      - !type:SpawnPrototype
+        prototype: CMSheetMetal1
+        amount: 4
+      - !type:DeleteEntity
       conditions:
-        - !type:EntityAnchored
-          anchored: false
+      - !type:EntityAnchored
+        anchored: false
       steps:
-        - tool: Screwing
-          doAfter: 6
+      - tool: Screwing
+        doAfter: 1
+      - tool: Prying
+        doAfter: 2
+    
     - to: nodeBurnUpgrade
       completed:
       - !type:SnapToGrid
@@ -37,6 +40,7 @@
       - material: MetalRod
         amount: 6
         doAfter: 6
+    
     - to: nodeBruteUpgrade
       completed:
       - !type:SnapToGrid
@@ -44,6 +48,7 @@
       - material: CMSteel
         amount: 3
         doAfter: 6
+    
     - to: nodeExplosiveUpgrade
       completed:
       - !type:SnapToGrid
@@ -59,43 +64,49 @@
       completed:
         - !type:SpawnPrototype
           prototype: CMSheetMetal1
-          amount: 2
+          amount: 4
         - !type:DeleteEntity
       conditions:
         - !type:EntityAnchored
           anchored: false
       steps:
-        - tool: Screwing
-          doAfter: 6
+      - tool: Screwing
+        doAfter: 1
+      - tool: Prying
+        doAfter: 2
 
   - node: nodeBruteUpgrade
     entity: CMBarricadeBrute
     edges:
     - to: start
       completed:
-        - !type:SpawnPrototype
-          prototype: CMSheetMetal1
-          amount: 2
-        - !type:DeleteEntity
+      - !type:SpawnPrototype
+        prototype: CMSheetMetal1
+        amount: 4
+      - !type:DeleteEntity
       conditions:
-        - !type:EntityAnchored
-          anchored: false
+      - !type:EntityAnchored
+        anchored: false
       steps:
-        - tool: Screwing
-          doAfter: 6
+      - tool: Screwing
+        doAfter: 1
+      - tool: Prying
+        doAfter: 2
 
   - node: nodeExplosiveUpgrade
     entity: CMBarricadeExplosive
     edges:
     - to: start
       completed:
-        - !type:SpawnPrototype
-          prototype: CMSheetMetal1
-          amount: 2
-        - !type:DeleteEntity
+      - !type:SpawnPrototype
+        prototype: CMSheetMetal1
+        amount: 4
+      - !type:DeleteEntity
       conditions:
-        - !type:EntityAnchored
-          anchored: false
+      - !type:EntityAnchored
+        anchored: false
       steps:
-        - tool: Screwing
-          doAfter: 6
+      - tool: Screwing
+        doAfter: 1
+      - tool: Prying
+        doAfter: 2

--- a/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/structures/barricade_metal_door.yml
+++ b/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/structures/barricade_metal_door.yml
@@ -12,21 +12,23 @@
       - !type:SnapToGrid
       steps:
       - material: CMSteel
-        amount: 5
-        doAfter: 4
+        amount: 6
+        doAfter: 3
 
   - node: nodeBarricadeMetalDoor
     entity: CMBarricadeMetalDoor
     edges:
     - to: start
       completed:
-        - !type:SpawnPrototype
-          prototype: CMSheetMetal1
-          amount: 4
-        - !type:DeleteEntity
+      - !type:SpawnPrototype
+        prototype: CMSheetMetal1
+        amount: 6
+      - !type:DeleteEntity
       conditions:
-        - !type:EntityAnchored
-          anchored: false
+      - !type:EntityAnchored
+        anchored: false
       steps:
-        - tool: Screwing
-          doAfter: 4
+      - tool: Screwing
+        doAfter: 1
+      - tool: Prying
+        doAfter: 5

--- a/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/structures/barricade_plasteel_door.yml
+++ b/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/structures/barricade_plasteel_door.yml
@@ -12,7 +12,7 @@
       - !type:SnapToGrid
       steps:
       - material: CMPlasteel
-        amount: 5
+        amount: 8
         doAfter: 4
 
   - node: nodeBarricadePlasteelDoor
@@ -20,13 +20,15 @@
     edges:
     - to: start
       completed:
-        - !type:SpawnPrototype
-          prototype: CMSheetPlasteel1
-          amount: 4
-        - !type:DeleteEntity
+      - !type:SpawnPrototype
+        prototype: CMSheetPlasteel1
+        amount: 8
+      - !type:DeleteEntity
       conditions:
-        - !type:EntityAnchored
-          anchored: false
+      - !type:EntityAnchored
+        anchored: false
       steps:
-        - tool: Screwing
-          doAfter: 4
+      - tool: Screwing
+        doAfter: 1
+      - tool: Prying
+        doAfter: 5

--- a/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/structures/barricade_turnstile.yml
+++ b/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/structures/barricade_turnstile.yml
@@ -20,13 +20,13 @@
     edges:
     - to: start
       completed:
-        - !type:SpawnPrototype
-          prototype: CMSheetMetal1
-          amount: 1
-        - !type:DeleteEntity
+      - !type:SpawnPrototype
+        prototype: CMSheetMetal1
+        amount: 1
+      - !type:DeleteEntity
       conditions:
-        - !type:EntityAnchored
-          anchored: false
+      - !type:EntityAnchored
+        anchored: false
       steps:
-        - tool: Screwing
-          doAfter: 3
+      - tool: Screwing
+        doAfter: 3

--- a/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/structures/catwalk.yml
+++ b/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/structures/catwalk.yml
@@ -3,24 +3,24 @@
   id: CMCatwalk
   start: start
   graph:
-    - node: start
-      edges:
-        - to: Catwalk
-          completed:
-            - !type:SnapToGrid
-              southRotation: true
-          steps:
-            - material: MetalRod
-              amount: 2
+  - node: start
+    edges:
+    - to: Catwalk
+      completed:
+      - !type:SnapToGrid
+        southRotation: true
+      steps:
+      - material: CMRodMetal
+        amount: 2
 
-    - node: Catwalk
-      entity: CMCatwalk
-      edges:
-        - to: start
-          completed:
-          - !type:SpawnPrototype
-                prototype: CMRodMetal1
-                amount: 2
-          - !type:DeleteEntity {}
-          steps:
-            - tool: Cutting
+  - node: Catwalk
+    entity: CMCatwalk
+    edges:
+    - to: start
+      completed:
+      - !type:SpawnPrototype
+        prototype: CMRodMetal1
+        amount: 2
+      - !type:DeleteEntity {}
+        steps:
+        - tool: Cutting

--- a/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/structures/catwalk.yml
+++ b/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/structures/catwalk.yml
@@ -22,5 +22,5 @@
         prototype: CMRodMetal1
         amount: 2
       - !type:DeleteEntity {}
-        steps:
-        - tool: Cutting
+      steps:
+      - tool: Cutting

--- a/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/structures/girder.yml
+++ b/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/structures/girder.yml
@@ -3,144 +3,103 @@
   id: CMGirder
   start: start
   graph:
-    - node: start
-      edges:
-        - to: girder
-          completed:
-            - !type:SnapToGrid
-              southRotation: true
-          steps:
-            - material: CMSteel
-              amount: 2
-              doAfter: 6
+  - node: start
+    edges:
+    - to: girder
+      completed:
+      - !type:SnapToGrid
+        southRotation: true
+      steps:
+      - material: CMSteel
+        amount: 2
+        doAfter: 6
 
-    - node: girder
-      entity: CMGirder
-      edges:
-        - to: start
-          completed:
-            - !type:SpawnPrototype
-              prototype: CMSheetMetal1
-              amount: 2
-            - !type:DeleteEntity {}
-          steps:
-            - tool: Screwing
-              doAfter: 4
-            - tool: Cutting
-              doAfter: 4
-            - tool: Anchoring
-              doAfter: 4
+  - node: girder
+    entity: CMGirder
+    edges:
+    - to: start
+      completed:
+      - !type:SpawnPrototype
+        prototype: CMSheetMetal1
+        amount: 2
+      - !type:DeleteEntity {}
+      steps:
+      - tool: Screwing
+        doAfter: 4
+      - tool: Cutting
+        doAfter: 4
+      - tool: Anchoring
+        doAfter: 4
 
-        - to: wall
-          completed:
-            - !type:SnapToGrid
-              southRotation: true
-          conditions:
-            - !type:EntityAnchored {}
-          steps:
-            - material: CMSteel
-              amount: 5
-              doAfter: 5
-            - tool: Screwing
-              doAfter: 5
-            - tool: Welding
-              doAfter: 4
+    - to: wall
+      completed:
+      - !type:SnapToGrid
+        southRotation: true
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - material: CMSteel
+        amount: 5
+        doAfter: 4
+      - tool: Screwing
+        doAfter: 4
+      - tool: Welding
+        doAfter: 5
 
-        - to: reinforcedGirder
-          completed:
-            - !type:SnapToGrid
-              southRotation: true
-          conditions:
-            - !type:EntityAnchored {}
-          steps:
-            - material: CMPlasteel
-              amount: 5
-              doAfter: 4
-            - material: CMRodMetal # TODO CM14 allow plasteel rods too
-              amount: 2
-              doAfter: 4
+    - to: reinforcedWall
+      completed:
+      - !type:SnapToGrid
+        southRotation: true
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - material: CMPlasteel
+        amount: 5
+        doAfter: 4
+      - material: CMRodMetal
+        amount: 2
+        doAfter: 0
+      - tool: Screwing
+        doAfter: 4
+      - tool: Welding
+        doAfter: 5
 
-    - node: wall
-      entity: CMWallMetal
-      edges:
-        - to: girder
-          completed:
-            - !type:GivePrototype
-              prototype: CMRodMetal1
-              amount: 1
-          steps:
-            - tool: Welding
-              doAfter: 6
-            - tool: Screwing
-              doAfter: 6
-            - tool: Cutting
-              doAfter: 6
-            - tool: Anchoring
-              doAfter: 6
-            - tool: Prying
-              doAfter: 6
+  - node: wall
+    entity: CMWallMetal
+    edges:
+    - to: girder
+      completed:
+      - !type:GivePrototype
+        prototype: CMRodMetal1
+        amount: 1
+      steps:
+      - tool: Welding
+        doAfter: 6
+      - tool: Screwing
+        doAfter: 6
+      - tool: Cutting
+        doAfter: 6
+      - tool: Anchoring
+        doAfter: 6
+      - tool: Prying
+        doAfter: 6
 
-    - node: reinforcedGirder
-      entity: CMGirderReinforced
-      edges:
-        - to: reinforcedWall
-          completed:
-            - !type:SnapToGrid
-              southRotation: true
-          conditions:
-            - !type:EntityAnchored { }
-          steps:
-            - tool: Screwing
-              doAfter: 6
-            - tool: Welding
-              doAfter: 6
-
-        - to: girder
-          completed:
-            - !type:SnapToGrid
-              southRotation: true
-          conditions:
-            - !type:EntityAnchored { }
-          steps:
-            - tool: Cutting
-              doAfter: 6
-
-    - node: reinforcedWall
-      entity: CMWallReinforced
-      edges:
-        - to: girder
-          completed:
-            - !type:SpawnPrototype
-              prototype: CMRodMetal1
-              amount: 1
-          steps:
-            - tool: Welding
-              doAfter: 6
-              completed:
-                - !type:VisualizerDataInt
-                  key: "enum.ReinforcedWallVisuals.DeconstructionStage"
-                  data: 4
-            - tool: Screwing
-              doAfter: 6
-              completed:
-              - !type:VisualizerDataInt
-                key: "enum.ReinforcedWallVisuals.DeconstructionStage"
-                data: 3
-            - tool: Cutting
-              doAfter: 6
-              completed:
-                - !type:VisualizerDataInt
-                  key: "enum.ReinforcedWallVisuals.DeconstructionStage"
-                  data: 2
-            - tool: Anchoring
-              doAfter: 6
-              completed:
-                - !type:VisualizerDataInt
-                  key: "enum.ReinforcedWallVisuals.DeconstructionStage"
-                  data: 1
-            - tool: Prying
-              doAfter: 6
-              completed:
-                - !type:VisualizerDataInt
-                  key: "enum.ReinforcedWallVisuals.DeconstructionStage"
-                  data: 0
+  - node: reinforcedWall
+    entity: CMWallReinforced
+    edges:
+    - to: girder
+      completed:
+      - !type:SpawnPrototype
+        prototype: CMRodMetal1
+        amount: 1
+      steps:
+      - tool: Welding
+        doAfter: 6
+      - tool: Screwing
+        doAfter: 6
+      - tool: Cutting
+        doAfter: 6
+      - tool: Anchoring
+        doAfter: 6
+      - tool: Prying
+        doAfter: 6

--- a/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/structures/windoor.yml
+++ b/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/structures/windoor.yml
@@ -38,9 +38,6 @@
         doAfter: 4
     
     - to: start
-      conditions:
-      - !type:EntityAnchored
-        anchored: false
       completed:
       - !type:SpawnPrototype
         prototype: CMSheetGlassReinforced1
@@ -123,9 +120,6 @@
         doAfter: 4
     
     - to: start
-      conditions:
-      - !type:EntityAnchored
-        anchored: false
       completed:
       - !type:SpawnPrototype
         prototype: CMSheetGlassReinforced1

--- a/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/structures/windoor.yml
+++ b/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/structures/windoor.yml
@@ -10,16 +10,8 @@
       - !type:SetAnchor
         value: false
       steps:
-      - material: CMSteel
-        amount: 4
-        doAfter: 2
-    - to: assemblySecure
-      completed:
-      - !type:SetAnchor
-        value: false
-      steps:
-      - material: CMPlasteel
-        amount: 4
+      - material: CMGlassReinforced
+        amount: 5
         doAfter: 2
 
   - node: assembly
@@ -28,47 +20,35 @@
     - !type:SnapToGrid {}
     - !type:SetAnchor {}
     edges:
-    - to: glass
-      conditions:
-      - !type:EntityAnchored {}
+    - to: assemblySecure
+      completed:
+      - !type:SetAnchor
+        value: false
       steps:
-      - material: CMGlass
-        amount: 5
-        doAfter: 1
+      - material: CMRodMetal
+        amount: 4
+        doAfter: 4
+    
+    - to: wired
+      conditions:
+      - !type:EntityAnchored { }
+      steps:
+      - material: Cable
+        amount: 1
+        doAfter: 4
+    
     - to: start
       conditions:
       - !type:EntityAnchored
         anchored: false
       completed:
       - !type:SpawnPrototype
-        prototype: CMSheetMetal1
-        amount: 4
+        prototype: CMSheetGlassReinforced1
+        amount: 5
       - !type:DeleteEntity {}
       steps:
       - tool: Welding
-        doAfter: 2
-
-  - node: glass
-    entity: CMWindoorAssembly
-    edges:
-    - to: wired
-      conditions:
-      - !type:EntityAnchored { }
-      steps:
-      - material: Cable
-        amount: 5
-        doAfter: 1
-    - to: assembly
-      conditions:
-      - !type:EntityAnchored
-        anchored: false
-      completed:
-      - !type:SpawnPrototype
-        prototype: CMSheetGlass1
-        amount: 5
-      steps:
-      - tool: Screwing
-        doAfter: 2
+        doAfter: 4
 
   - node: wired
     entity: CMWindoorAssembly
@@ -83,15 +63,16 @@
         icon:
           sprite: "Objects/Misc/module.rsi"
           state: "door_electronics"
-        doAfter: 1
-    - to: glass
+        doAfter: 4
+    
+    - to: assembly
       completed:
       - !type:SpawnPrototype
         prototype: CableApcStack1
-        amount: 5
+        amount: 1
       steps:
       - tool: Cutting
-        doAfter: 1
+        doAfter: 4
 
   - node: electronics
     entity: CMWindoorAssembly
@@ -101,7 +82,14 @@
       - !type:EntityAnchored {}
       steps:
       - tool: Screwing
-        doAfter: 2
+        doAfter: 4
+    
+    - to: wired
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - tool: Prying
+        doAfter: 4
 
   - node: windoor
     entity: CMWindoor
@@ -109,8 +97,6 @@
     - to: wired
       conditions:
       - !type:EntityAnchored {}
-      - !type:DoorBolted
-        value: false
       - !type:WirePanel {}
       - !type:AllWiresCut
       completed:
@@ -118,46 +104,25 @@
         pickup: true
         emptyAtUser: true
       steps:
-      - tool: Anchoring
-        doAfter: 1
+      - tool: Prying
+        doAfter: 4
 
+  ## Secure windoor
   - node: assemblySecure
     entity: CMWindoorAssemblySecure
     actions:
     - !type:SnapToGrid { }
     - !type:SetAnchor { }
     edges:
-    - to: glassSecure
-      conditions:
-      - !type:EntityAnchored { }
-      steps:
-      - material: CMGlassReinforced
-        amount: 5
-        doAfter: 1
-    - to: start
-      conditions:
-      - !type:EntityAnchored
-        anchored: false
-      completed:
-      - !type:SpawnPrototype
-        prototype: CMSheetPlasteel1
-        amount: 4
-      - !type:DeleteEntity { }
-      steps:
-      - tool: Welding
-        doAfter: 10
-
-  - node: glassSecure
-    entity: CMWindoorAssemblySecure
-    edges:
     - to: wiredSecure
       conditions:
       - !type:EntityAnchored { }
       steps:
       - material: Cable
-        amount: 5
-        doAfter: 1
-    - to: assemblySecure
+        amount: 1
+        doAfter: 4
+    
+    - to: start
       conditions:
       - !type:EntityAnchored
         anchored: false
@@ -165,17 +130,20 @@
       - !type:SpawnPrototype
         prototype: CMSheetGlassReinforced1
         amount: 5
+      - !type:SpawnPrototype
+        prototype: CMRodMetal1
+        amount: 4
+      - !type:DeleteEntity { }
       steps:
-      - tool: Screwing
-        doAfter: 4
-
+      - tool: Welding
+        doAfter: 10
 
   - node: wiredSecure
     entity: CMWindoorAssemblySecure
     edges:
     - to: electronicsSecure
       conditions:
-      - !type:EntityAnchored { }
+      - !type:EntityAnchored {}
       steps:
       - tag: DoorElectronics
         store: board
@@ -183,42 +151,46 @@
         icon:
           sprite: "Objects/Misc/module.rsi"
           state: "door_electronics"
-        doAfter: 1
-    - to: glassSecure
+        doAfter: 4
+    
+    - to: assemblySecure
       completed:
       - !type:SpawnPrototype
         prototype: CableApcStack1
-        amount: 5
+        amount: 1
       steps:
       - tool: Cutting
-        doAfter: 3
+        doAfter: 4
 
   - node: electronicsSecure
     entity: CMWindoorAssemblySecure
     edges:
     - to: windoorSecure
       conditions:
-      - !type:EntityAnchored { }
+      - !type:EntityAnchored {}
       steps:
       - tool: Screwing
+        doAfter: 4
+    
+    - to: wiredSecure
+      conditions:
+      - !type:EntityAnchored {}
+      steps:
+      - tool: Prying
         doAfter: 4
 
   - node: windoorSecure
     entity: CMWindoorSecure
     edges:
-    - to: wired
+    - to: wiredSecure
       conditions:
       - !type:EntityAnchored {}
-      - !type:DoorBolted
-        value: false
       - !type:WirePanel {}
-      - !type:ContainerNotEmpty
-        container: board
       - !type:AllWiresCut
       completed:
       - !type:EmptyAllContainers
         pickup: true
         emptyAtUser: true
       steps:
-      - tool: Anchoring
+      - tool: Prying
         doAfter: 4

--- a/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/utilities/apc.yml
+++ b/Resources/Prototypes/_CM14/Recipes/Construction/Graphs/utilities/apc.yml
@@ -3,44 +3,52 @@
   id: CMApc
   start: start
   graph:
-    - node: start
-      edges:
-        - to: apcFrame
-          steps:
-            - material: CMSteel
-              amount: 2
-            - material: Cable
-              amount: 5
+  - node: start
+    edges:
+    - to: apcFrame
+      steps:
+      - material: CMSteel
+        amount: 2
+        doAfter: 0
+      - material: Cable
+        amount: 10
+        doAfter: 2
 
-    - node: apcFrame
-      entity: CMApcFrame
-      edges:
-        - to: apc
-          steps:
-            - component: ApcElectronics
-              name: "APC electronics"
-              doAfter: 2
-        - to: start
-          completed:
-            - !type:GivePrototype
-              prototype: CMSheetMetal1
-              amount: 2
-            - !type:DeleteEntity {}
-          steps:
-            - tool: Screwing
-              doAfter: 2
+  - node: apcFrame
+    entity: CMApcFrame
+    edges:
+    - to: apc
+      steps:
+      - component: ApcElectronics
+        name: "power control module"
+        icon:
+          sprite: "_CM14/Objects/Misc/module.rsi"
+          state: "power_mod"
+        doAfter: 1.5
+      - tool: Screwing
+        doAfter: 0
+    
+    - to: start
+      completed:
+      - !type:GivePrototype
+        prototype: CMSheetMetal1
+        amount: 2
+      - !type:DeleteEntity {}
+      steps:
+      - tool: Welding
+        doAfter: 5
 
-    - node: apc
-      entity: CMApcConstructed
-      edges:
-        - to: apcFrame
-          completed:
-            - !type:GivePrototype
-              prototype: CMAPCElectronics
-              amount: 1
-          conditions:
-            - !type:WirePanel
-              open: true
-          steps:
-            - tool: Prying
-              doAfter: 4
+  - node: apc
+    entity: CMApcConstructed
+    edges:
+    - to: apcFrame
+      completed:
+      - !type:GivePrototype
+        prototype: CMAPCElectronics
+        amount: 1
+      conditions:
+      - !type:WirePanel
+        open: true
+      steps:
+      - tool: Prying
+        doAfter: 5

--- a/Resources/Prototypes/_CM14/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/_CM14/Recipes/Construction/structures.yml
@@ -18,24 +18,24 @@
   conditions:
     - !type:TileNotBlocked
 
-- type: construction
-  parent: CM
-  id: CMGirderReinforced
-  name: reinforced girder
-  graph: CMGirder
-  startNode: start
-  targetNode: reinforcedGirder
-  category: construction-category-cm-structures
-  description: A large structural assembly made out of metal and plasteel.
-  icon:
-    sprite: _CM14/Structures/Walls/girder.rsi
-    state: reinforced
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canRotate: false
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
+#- type: construction
+#  parent: CM
+#  id: CMGirderReinforced
+#  name: reinforced girder
+#  graph: CMGirder
+#  startNode: start
+#  targetNode: reinforcedGirder
+#  category: construction-category-cm-structures
+#  description: A large structural assembly made out of metal and plasteel.
+#  icon:
+#    sprite: _CM14/Structures/Walls/girder.rsi
+#    state: reinforced
+#  objectType: Structure
+#  placementMode: SnapgridCenter
+#  canRotate: false
+#  canBuildInImpassable: false
+#  conditions:
+#    - !type:TileNotBlocked
 
 - type: construction
   parent: CM

--- a/Resources/Prototypes/_CM14/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/_CM14/Recipes/Construction/structures.yml
@@ -251,6 +251,7 @@
   targetNode: Catwalk
   category: construction-category-cm-structures
   description: Just like a lattice. Except it looks better.
+  placementMode: SnapgridCenter
   icon:
     sprite: _CM14/Structures/catwalk.rsi
     state: catwalk


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Girders and other structures marines can build now drop the CM14 versions of materials instead of the vanilla SS14 ones.
All current recipes made identical to the ones in CM13. Excluding the APC, the turnstiles and the windoors:
- I can't really make APCs be built like CM13 ones in a way that won't require editing when/if we get swapping power cells and such, so for now they're just closer, not identical.
- The turnstiles don't appear to be constructible in CM13, so I left them as is.
- I changed the final construction for windoors from using a crowbar to using a screwdriver to be consistent with the usual pattern of "screwdriver to secure board, crowbar to pull it out."

Reinforced girder removed from the construction menu.

Airlock assemblies now properly change their sprites during construction.

Closes #2389

## Why / Balance
From what I understand, the plan is to attempt to get CM14 as close to CM13 as possible. Hence the changes to material numbers and construction steps.

As far as I can tell, marines can only build normal girders in CM13, and both normal walls and rwalls are built using them. So, since the reinforced girder doesn't actually *do* anything, I removed it from the crafting menu until we find a use for it.

## Media
Airlocks in different stages of construction:
![airlocks](https://github.com/CM-14/CM-14/assets/84070966/b78dcdb2-04c4-434a-ae6a-3163633ecea5)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Sigil
- remove: Reinforced girder removed from crafting menu, as it currently has no use.
- tweak: Where possible, changed the material requirements and construction steps for objects marines can build to match their CM13 versions.
- fix: Made girders and other constructible objects drop the CM14 versions of materials.
- fix: Made catwalks snap to the grid properly.
- fix: Made airlocks properly change their appearance during construction.
