### PR TITLE
Fixes hypersleep pods

### DIFF
--- a/Content.Client/_CM14/Marines/HyperSleep/HyperSleepChamberSystem.cs
+++ b/Content.Client/_CM14/Marines/HyperSleep/HyperSleepChamberSystem.cs
@@ -5,19 +5,4 @@ namespace Content.Client._CM14.Marines.HyperSleep;
 
 public sealed class HyperSleepChamberSystem : SharedHyperSleepChamberSystem
 {
-    protected override void ChamberFilled(Entity<HyperSleepChamberComponent> chamber)
-    {
-        base.ChamberFilled(chamber);
-
-        if (TryComp(chamber, out SpriteComponent? sprite))
-            sprite.LayerSetState(HyperSleepChamberLayers.Base, chamber.Comp.FilledState);
-    }
-
-    protected override void ChamberEmptied(Entity<HyperSleepChamberComponent> chamber)
-    {
-        base.ChamberEmptied(chamber);
-
-        if (TryComp(chamber, out SpriteComponent? sprite))
-            sprite.LayerSetState(HyperSleepChamberLayers.Base, chamber.Comp.EmptyState);
-    }
 }

--- a/Content.Shared/_CM14/Marines/HyperSleep/HyperSleepChamberComponent.cs
+++ b/Content.Shared/_CM14/Marines/HyperSleep/HyperSleepChamberComponent.cs
@@ -8,13 +8,7 @@ namespace Content.Shared._CM14.Marines.HyperSleep;
 public sealed partial class HyperSleepChamberComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public string ContainerId = "cm_hyper_sleep";
-
-    [DataField, AutoNetworkedField]
-    public string EmptyState = "open";
-
-    [DataField, AutoNetworkedField]
-    public string FilledState = "closed";
+    public string ContainerId = "cm-hypersleep";
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/_CM14/Marines/HyperSleep/SharedHyperSleepChamberSystem.cs
+++ b/Content.Shared/_CM14/Marines/HyperSleep/SharedHyperSleepChamberSystem.cs
@@ -17,7 +17,6 @@ public abstract class SharedHyperSleepChamberSystem : EntitySystem
     {
         SubscribeLocalEvent<HyperSleepChamberComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<HyperSleepChamberComponent, EntInsertedIntoContainerMessage>(OnInserted);
-        SubscribeLocalEvent<HyperSleepChamberComponent, EntRemovedFromContainerMessage>(OnRemoved);
 
         SubscribeLocalEvent<InsideHyperSleepChamberComponent, MoveInputEvent>(OnMoveInput);
 
@@ -33,21 +32,6 @@ public abstract class SharedHyperSleepChamberSystem : EntitySystem
     {
         if (!_timing.ApplyingState)
             EnsureComp<InsideHyperSleepChamberComponent>(args.Entity).Chamber = ent;
-
-        if (_containers.TryGetContainer(ent, ent.Comp.ContainerId, out var container) &&
-            container.Count > 0)
-        {
-            ChamberFilled(ent);
-        }
-    }
-
-    private void OnRemoved(Entity<HyperSleepChamberComponent> ent, ref EntRemovedFromContainerMessage args)
-    {
-        if (_containers.TryGetContainer(ent, ent.Comp.ContainerId, out var container) &&
-            container.Count == 0)
-        {
-            ChamberEmptied(ent);
-        }
     }
 
     private void OnMoveInput(Entity<InsideHyperSleepChamberComponent> ent, ref MoveInputEvent args)
@@ -58,7 +42,6 @@ public abstract class SharedHyperSleepChamberSystem : EntitySystem
         if (ent.Comp.Chamber is not { } chamber)
             return;
 
-        _containers.RemoveEntity(chamber, ent);
         RemCompDeferred<InsideHyperSleepChamberComponent>(ent);
 
         var outside = EnsureComp<OutsideHyperSleepChamberComponent>(ent);
@@ -70,14 +53,6 @@ public abstract class SharedHyperSleepChamberSystem : EntitySystem
     {
         if (ent.Comp.Chamber == args.OtherEntity)
             args.Cancelled = true;
-    }
-
-    protected virtual void ChamberFilled(Entity<HyperSleepChamberComponent> chamber)
-    {
-    }
-
-    protected virtual void ChamberEmptied(Entity<HyperSleepChamberComponent> chamber)
-    {
     }
 
     public override void Update(float frameTime)

--- a/Resources/Prototypes/_CM14/Entities/Structures/Machines/hypersleep.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Machines/hypersleep.yml
@@ -32,16 +32,16 @@
         layer:
         - MachineLayer
   - type: DragInsertContainer
-    containerId: cm_hyper_sleep
+    containerId: cm-hypersleep
   - type: ExitContainerOnMove
-    containerId: cm_hyper_sleep
+    containerId: cm-hypersleep
   - type: ContainerContainer
     containers:
-      cm_hyper_sleep:
+      cm-hypersleep:
         !type:ContainerSlot
   - type: HyperSleepChamber
   - type: Cryostorage
-    containerId: cm_hyper_sleep
+    containerId: cm-hypersleep
   - type: Appearance
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/_CM14/Entities/Structures/Machines/hypersleep.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Machines/hypersleep.yml
@@ -13,6 +13,12 @@
     layers:
     - state: open
       map: [ "enum.HyperSleepChamberLayers.Base" ]
+  - type: UserInterface
+    interfaces:
+      enum.CryostorageUIKey.Key:
+        type: CryostorageBoundUserInterface
+  - type: ActivatableUI
+    key: enum.CryostorageUIKey.Key
   - type: InteractionOutline
   - type: Fixtures
     fixtures:
@@ -25,11 +31,24 @@
         - MachineMask
         layer:
         - MachineLayer
+  - type: DragInsertContainer
+    containerId: cm_hyper_sleep
+  - type: ExitContainerOnMove
+    containerId: cm_hyper_sleep
   - type: ContainerContainer
     containers:
-      scanner-body:
+      cm_hyper_sleep:
         !type:ContainerSlot
   - type: HyperSleepChamber
+  - type: Cryostorage
+    containerId: cm_hyper_sleep
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.CryostorageVisuals.Full:
+        enum.HyperSleepChamberLayers.Base:
+          True: { state: closed }
+          False: { state: open }
 
 - type: entity
   parent: CMHyperSleepChamber


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Hypersleep chambers can now be used to go into cryo. No shared storage like in CM13 yet, just what we have from base SS14, but I'd say better this than having no option except to go SSD when you need to leave the round.

Closes #2359

## Technical details
Extraneous code removed from the systems that manage the pods — there's already a component for changing an object's sprite if it's full and another component for leaving an object on pressing a movement key.

The actual cryostorage is handled by the same component as in the base game. If we want to use CM13's shared cryo inventory, we'll probably have to either completely reimplement it or figure out a workaround.

The hypersleep chamber slot name was changed from `cm_hyper_sleep` to `cm-hypersleep`, as from what I can tell, the usual convention for this uses dashes.

## Media
![pods](https://github.com/CM-14/CM-14/assets/84070966/19bcc90f-dfd6-44ec-b62f-2c38637c300b)
![podui](https://github.com/CM-14/CM-14/assets/84070966/471003d0-b452-4f2a-9a4a-13032b54c344)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Sigil
- add: Hypersleep pods now function as cryo pods.
