### PR TITLE
88 mod damage modifier

### DIFF
--- a/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Guns/Pistols/uscm_pistols.yml
+++ b/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Guns/Pistols/uscm_pistols.yml
@@ -109,6 +109,8 @@
         whitelist:
           tags:
           - CMMagazinePistol88m4AP
+  - type: GunDamageModifier
+    multiplier: 1.2
 
 - type: entity
   parent: CMWeaponPistolBase


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Adds a 1.2 damage multiplier to the 88 Mod 4 sidearm.

## Why / Balance
It is this way in CM13, makes it more competitive with the other pistols. 


## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

