### PR TITLE
Optimise pheromones

### DIFF
--- a/Content.Shared/_CM14/Xenos/Pheromones/SharedXenoPheromonesSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Pheromones/SharedXenoPheromonesSystem.cs
@@ -317,8 +317,6 @@ public abstract class SharedXenoPheromonesSystem : EntitySystem
 
     private record struct PheromonesJob() : IParallelRobustJob
     {
-        public int BatchSize => 4;
-
         public EntityLookupSystem Lookup;
 
         public ValueList<(

--- a/Content.Shared/_CM14/Xenos/Pheromones/SharedXenoPheromonesSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Pheromones/SharedXenoPheromonesSystem.cs
@@ -9,7 +9,6 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Weapons.Melee.Events;
-using Microsoft.Extensions.ObjectPool;
 using Robust.Shared.Collections;
 using Robust.Shared.GameStates;
 using Robust.Shared.Threading;

--- a/Content.Shared/_CM14/Xenos/Pheromones/SharedXenoPheromonesSystem.cs
+++ b/Content.Shared/_CM14/Xenos/Pheromones/SharedXenoPheromonesSystem.cs
@@ -231,18 +231,21 @@ public abstract class SharedXenoPheromonesSystem : EntitySystem
 
         while (query.MoveNext(out var uid, out var active, out var pheromones, out var xform))
         {
-            if (_timing.CurTime >= pheromones.NextPheromonesPlasmaUse)
+            // We'll only update pheromones receivers whenever plasma gets used.
+            // This avoids us having to do lookups every tick.
+            if (_timing.CurTime < pheromones.NextPheromonesPlasmaUse)
             {
-                pheromones.NextPheromonesPlasmaUse += _pheromonePlasmaUseDelay;
-                if (!_xenoPlasma.TryRemovePlasma(uid, pheromones.PheromonesPlasmaUpkeep))
-                {
-                    RemCompDeferred<XenoActivePheromonesComponent>(uid);
-                    continue;
-                }
-
-                Dirty(uid, pheromones);
+                continue;
             }
 
+            pheromones.NextPheromonesPlasmaUse += _pheromonePlasmaUseDelay;
+            if (!_xenoPlasma.TryRemovePlasma(uid, pheromones.PheromonesPlasmaUpkeep))
+            {
+                RemCompDeferred<XenoActivePheromonesComponent>(uid);
+                continue;
+            }
+
+            Dirty(uid, pheromones);
             _pheromonesJob.Pheromones.Add((uid, active, pheromones, xform));
         }
 


### PR DESCRIPTION
On playtest this was 2x as expensive as physics.
RefreshMoveSpeedModifiers is still pretty expensive and you would need some thread-safe wrapper for it if you wanted that fixed too.

I tested with 25 queens in close proximity 15 running recovery pheromones for 30 seconds. I cbfd getting release working so profile is on debug but it should still be somewhat indicative.

Left before Right after:

![image](https://github.com/CM-14/CM-14/assets/31366439/e777e1a0-f215-4b0d-ad20-2c69ee7b0927)

Profile was before only running it every second which would also have a huge performance impact.

Still want to:
- Change the lookupflags to approx to make it significantly faster.
- ~~Add NextUpdate fields so they don't all run at the same time.~~