### PR TITLE
Fix marines getting stuck on hypersleep chambers at roundstart and having their inventory visually disappear in certain spots

### DIFF
--- a/Content.Shared/_CM14/Marines/HyperSleep/SharedHyperSleepChamberSystem.cs
+++ b/Content.Shared/_CM14/Marines/HyperSleep/SharedHyperSleepChamberSystem.cs
@@ -25,7 +25,7 @@ public abstract class SharedHyperSleepChamberSystem : EntitySystem
 
     private void OnMapInit(Entity<HyperSleepChamberComponent> ent, ref MapInitEvent args)
     {
-        _containers.EnsureContainer<ContainerSlot>(ent, ent.Comp.ContainerId);
+        _containers.EnsureContainer<Container>(ent, ent.Comp.ContainerId);
     }
 
     private void OnInserted(Entity<HyperSleepChamberComponent> ent, ref EntInsertedIntoContainerMessage args)

--- a/Resources/Prototypes/_CM14/Entities/Structures/Machines/hypersleep.yml
+++ b/Resources/Prototypes/_CM14/Entities/Structures/Machines/hypersleep.yml
@@ -38,7 +38,7 @@
   - type: ContainerContainer
     containers:
       cm-hypersleep:
-        !type:ContainerSlot
+        !type:Container
   - type: HyperSleepChamber
   - type: Cryostorage
     containerId: cm-hypersleep


### PR DESCRIPTION
## About the PR
Fix #2436 

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed marines getting stuck on hypersleep chambers at roundstart and having their inventory visually disappear in certain spots.
