### PR TITLE
adds death text to xenomorphs

### DIFF
--- a/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_CM14/Entities/Mobs/Xeno/base_xeno.yml
@@ -100,6 +100,7 @@
   - type: ContentEye
   - type: CameraRecoil
   - type: MindContainer
+    showExamineInfo: true
   - type: StatusIcon
   - type: RotationVisuals
     defaultRotation: 0


### PR DESCRIPTION
- fix #2353 

**Changelog**

Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl: Whisper
- add: Xenos now have death text on examine.
