### PR TITLE
rules updates

### DIFF
--- a/Resources/Prototypes/_CM14/Guidebook/CMRules.yml
+++ b/Resources/Prototypes/_CM14/Guidebook/CMRules.yml
@@ -222,3 +222,11 @@
   priority: 24
   ruleEntry: true
   text: "/ServerInfo/Guidebook/_CM14/Rules/Roleplay/CMHostileFactionRoleplay.xml"
+
+- type: guideEntry
+  parent: CM
+  id: CMCommandChain
+  name: cm-guide-entry-rules-command-chain
+  priority: 25
+  ruleEntry: true
+  text: "/ServerInfo/Guidebook/_CM14/Rules/Roleplay/CMCommandChain.xml"

--- a/Resources/ServerInfo/Guidebook/_CM14/CM14.xml
+++ b/Resources/ServerInfo/Guidebook/_CM14/CM14.xml
@@ -15,4 +15,5 @@
   New to CM14 or have no CM13 experience? Be careful! A lot of mechanics and values are not the same as SS14.
   (It's recomended to read the guidebook and learn basic controls from another server if this is your first time in SS14.)
   - [textlink="New player guide!" link="CMGuideNewPlayer"]
+  - [textlink="Medicines" link="CMMedicine"]
 </Document>

--- a/Resources/ServerInfo/Guidebook/_CM14/Rules/MilitaryCommand/CMMarineLaw.xml
+++ b/Resources/ServerInfo/Guidebook/_CM14/Rules/MilitaryCommand/CMMarineLaw.xml
@@ -4,7 +4,7 @@
   - Laws are interpreted through chain of command, and a decision may be overruled by a higher position.
   - MP may only perform arrests in secure areas; FOB, USCM Flagships.
   - Exceptions can be made if the offending personnel is fleeing away from a secure area.
-  - Arrests should not be performed if there are hostile forces aboard the flagship.
+  - Arrests should not be performed if there are hostile forces aboard the warship.
   - Exceptions can be made if the offending personnel is a threat to the crew.
 
 </Document>

--- a/Resources/ServerInfo/Guidebook/_CM14/Rules/MilitaryCommand/CMMarineLaw.xml
+++ b/Resources/ServerInfo/Guidebook/_CM14/Rules/MilitaryCommand/CMMarineLaw.xml
@@ -2,4 +2,9 @@
   # Marine Law
   Marine law is not yet created for this server, however, https://cm-ss13.com/wiki/Marine_Law may be used for crimes and punishments in the sections from "Optional" to "Precautionary Charges".
   - Laws are interpreted through chain of command, and a decision may be overruled by a higher position.
+  - MP may only perform arrests in secure areas; FOB, USCM Flagships.
+  - Exceptions can be made if the offending personnel is fleeing away from a secure area.
+  - Arrests should not be performed if there are hostile forces aboard the flagship.
+  - Exceptions can be made if the offending personnel is a threat to the crew.
+
 </Document>

--- a/Resources/ServerInfo/Guidebook/_CM14/Rules/Overview.xml
+++ b/Resources/ServerInfo/Guidebook/_CM14/Rules/Overview.xml
@@ -61,4 +61,5 @@
   - [textlink="5. Xenos." link="CMXenoRoleplay"]
   - [textlink="6. Survivors." link="CMSurvivorRoleplay"]
   - [textlink="7. Hostile Factions." link="CMHostileFactionRoleplay"]
+  - [textlink="8. Chain of Command." link="CMCommandChain"]
 </Document>

--- a/Resources/ServerInfo/Guidebook/_CM14/Rules/Roleplay/CMCommandChain.xml
+++ b/Resources/ServerInfo/Guidebook/_CM14/Rules/Roleplay/CMCommandChain.xml
@@ -1,7 +1,7 @@
 ﻿<Document>
 
   #Chain of Command
-  Should the Flagship Commander become unfit to command, be it due to absence, SSD, Death, imprisonment or other circumstances, the next person on this list assumes command.
+  Should the warship Commander become unfit to command, be it due to absence, SSD, Death, imprisonment or other circumstances, the next person on this list assumes command.
   \nThe person in command of the operation does not assume a new rank rank, title or powers such as access changes, but other personnel must follow their orders that pertain to directing the operation.
   - Commanding Officer
   - Executive Officer

--- a/Resources/ServerInfo/Guidebook/_CM14/Rules/Roleplay/CMCommandChain.xml
+++ b/Resources/ServerInfo/Guidebook/_CM14/Rules/Roleplay/CMCommandChain.xml
@@ -1,0 +1,21 @@
+﻿<Document>
+
+  #Chain of Command
+  Should the Flagship Commander become unfit to command, be it due to absence, SSD, Death, imprisonment or other circumstances, the next person on this list assumes command.
+  \nThe person in command of the operation does not assume a new rank rank, title or powers such as access changes, but other personnel must follow their orders that pertain to directing the operation.
+  - Commanding Officer
+  - Executive Officer
+  - Auxiliary Support Officer
+  - Chief MP
+  - Chief Medical Officer
+  - Staff Officer
+  - Chief Engineer
+  - Pilot Officer
+  - Intelligence Officer
+  - Quartermaster
+  - Senior Enlisted Advisor
+  - Warden
+  - Military Police
+  - Squad Leader (Starts at Alpha and goes through the squads)
+  - Ranking military personnel (Any squad role, starting at Alpha and through the squads.)
+</Document>

--- a/Resources/ServerInfo/Guidebook/_CM14/Rules/Roleplay/CMCommandRoleplay.xml
+++ b/Resources/ServerInfo/Guidebook/_CM14/Rules/Roleplay/CMCommandRoleplay.xml
@@ -2,6 +2,6 @@
   #Command
   - A briefing must be conducted at the start of every operation.
   - Command must attempt to direct marines to build defenses at the landing zone. (FOB)
-  - When assigning a new flagship commander, follow the chain of command whenever possible.
+  - When assigning a new warship commander, follow the chain of command whenever possible.
   - [textlink="Chain of Command" link="CMCommandChain"]
 </Document>

--- a/Resources/ServerInfo/Guidebook/_CM14/Rules/Roleplay/CMCommandRoleplay.xml
+++ b/Resources/ServerInfo/Guidebook/_CM14/Rules/Roleplay/CMCommandRoleplay.xml
@@ -2,4 +2,6 @@
   #Command
   - A briefing must be conducted at the start of every operation.
   - Command must attempt to direct marines to build defenses at the landing zone. (FOB)
+  - When assigning a new flagship commander, follow the chain of command whenever possible.
+  - [textlink="Chain of Command" link="CMCommandChain"]
 </Document>

--- a/Resources/ServerInfo/Guidebook/_CM14/Rules/Roleplay/CMUSCMDeployment.xml
+++ b/Resources/ServerInfo/Guidebook/_CM14/Rules/Roleplay/CMUSCMDeployment.xml
@@ -12,5 +12,5 @@
   - The CMO may give permission to doctors so they may treat marines within the FOB.
   - The CMP may give permission to MP so they may make arrests within the FOB.
   - Combat Correspondents focus on reporting on combat and disengage when attacked.
-  - CO, XO may deploy if they assign a new flagship commander (The person in charge of the flagship crew)
+  - CO, XO may deploy if they assign a new warship commander (The person in charge of the warship crew)
 </Document>

--- a/Resources/ServerInfo/Guidebook/_CM14/Rules/Roleplay/CMUSCMDeployment.xml
+++ b/Resources/ServerInfo/Guidebook/_CM14/Rules/Roleplay/CMUSCMDeployment.xml
@@ -9,6 +9,7 @@
 
   ##Ship crew may deploy, where relevant.
   - Maint techs may assist building FOB.
-  - Doctors may treat marines within the FOB.
+  - The CMO may give permission to doctors so they may treat marines within the FOB.
+  - The CMP may give permission to MP so they may make arrests within the FOB.
   - Combat Correspondents focus on reporting on combat and disengage when attacked.
 </Document>

--- a/Resources/ServerInfo/Guidebook/_CM14/Rules/Roleplay/CMUSCMDeployment.xml
+++ b/Resources/ServerInfo/Guidebook/_CM14/Rules/Roleplay/CMUSCMDeployment.xml
@@ -12,4 +12,5 @@
   - The CMO may give permission to doctors so they may treat marines within the FOB.
   - The CMP may give permission to MP so they may make arrests within the FOB.
   - Combat Correspondents focus on reporting on combat and disengage when attacked.
+  - CO, XO may deploy if they assign a new flagship commander (The person in charge of the flagship crew)
 </Document>

--- a/Resources/ServerInfo/Guidebook/_CM14/Rules/Roleplay/CMXenoRoleplay.xml
+++ b/Resources/ServerInfo/Guidebook/_CM14/Rules/Roleplay/CMXenoRoleplay.xml
@@ -18,6 +18,6 @@
   - Xenos can sense the marine ships and are aware they may be attacked shortly.
 
 
-  - If you are a xenomorph attacking aboard a flagship (Almayer) prior to hijack, [color=#ff0000]attacking newly spawned players in cryo is forbidden, let them have a chance to gear up before you attack them![/color] Avoiding the cryo rooms unless the USCM are using them as cover will be enough.
+  - If you are a xenomorph attacking aboard a warship (Almayer) prior to hijack, [color=#ff0000]attacking newly spawned players in cryo is forbidden, let them have a chance to gear up before you attack them![/color] Avoiding the cryo rooms unless the USCM are using them as cover will be enough.
 
 </Document>


### PR DESCRIPTION
doctors and mp may deploy to fob with permission from head

in addition;
- MP may not arrest outside of FOB and Almayer unless in a chase
- MP may not arrest while hostile forces are on the almayer unless the person is a threat

:cl: Whisper

- tweak: Rules tweak; MP may not arrest outside of FOB and flagship unless in a chase.
- tweak: Rules tweak; MP may not arrest while hostile forces are on the flagship unless the person is a threat.
- tweak: Rules tweak; Doctors and MP may deploy to fob with permission from their respective heads.
- tweak: Rules tweak; CO and XO may deploy if they assign a new flagship commander.
- add: New guidebook page on chain of command can be found in roleplay rules.
