### PR TITLE
make puddles less prevalent

### DIFF
--- a/Content.Shared/Fluids/Components/PuddleComponent.cs
+++ b/Content.Shared/Fluids/Components/PuddleComponent.cs
@@ -15,7 +15,7 @@ namespace Content.Shared.Fluids.Components
         public SoundSpecifier SpillSound = new SoundPathSpecifier("/Audio/Effects/Fluids/splat.ogg");
 
         [DataField]
-        public FixedPoint2 OverflowVolume = FixedPoint2.New(20);
+        public FixedPoint2 OverflowVolume = FixedPoint2.New(1000);
 
         [DataField("solution")] public string SolutionName = "puddle";
 

--- a/Content.Shared/Fluids/Components/PuddleComponent.cs
+++ b/Content.Shared/Fluids/Components/PuddleComponent.cs
@@ -15,7 +15,7 @@ namespace Content.Shared.Fluids.Components
         public SoundSpecifier SpillSound = new SoundPathSpecifier("/Audio/Effects/Fluids/splat.ogg");
 
         [DataField]
-        public FixedPoint2 OverflowVolume = FixedPoint2.New(1000);
+        public FixedPoint2 OverflowVolume = FixedPoint2.New(10000);
 
         [DataField("solution")] public string SolutionName = "puddle";
 


### PR DESCRIPTION
Limits puddle spreading to 1000 units
Puddles also scale with that limit, which *should* mean puddles won't be obnoxiously in the way and contained to at most three tiles in worst cases.

**Changelog**

:cl: Whisper
- tweak: Made puddles smaller and spread less easily, requiring a lot more liquid to do anything.


