### PR TITLE
Added a shared empty layer state for storages

### DIFF
--- a/Content.Shared/Storage/Components/SharedEmptyStorageVisuals.cs
+++ b/Content.Shared/Storage/Components/SharedEmptyStorageVisuals.cs
@@ -1,0 +1,17 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Storage.Components
+{
+    [Serializable, NetSerializable]
+    public enum SharedEmptyStorageVisuals : byte
+    {
+        StorageState,
+    }
+
+    [Serializable, NetSerializable]
+    public enum SharedStorageState : byte
+    {
+        Empty,
+        NotEmpty,
+    }
+}

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -39,23 +39,23 @@ namespace Content.Shared.Storage.EntitySystems;
 
 public abstract class SharedStorageSystem : EntitySystem
 {
-    [Dependency] private   readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] protected readonly IRobustRandom Random = default!;
     [Dependency] protected readonly ActionBlockerSystem ActionBlocker = default!;
-    [Dependency] private   readonly EntityLookupSystem _entityLookupSystem = default!;
-    [Dependency] private   readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly EntityLookupSystem _entityLookupSystem = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] protected readonly SharedAudioSystem Audio = default!;
-    [Dependency] private   readonly SharedContainerSystem _containerSystem = default!;
-    [Dependency] private   readonly SharedDoAfterSystem _doAfterSystem = default!;
+    [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
     [Dependency] protected readonly SharedEntityStorageSystem EntityStorage = default!;
-    [Dependency] private   readonly SharedInteractionSystem _interactionSystem = default!;
-    [Dependency] private   readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] protected readonly SharedItemSystem ItemSystem = default!;
-    [Dependency] private   readonly SharedPopupSystem _popupSystem = default!;
-    [Dependency] private   readonly SharedHandsSystem _sharedHandsSystem = default!;
-    [Dependency] private   readonly SharedStackSystem _stack = default!;
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+    [Dependency] private readonly SharedHandsSystem _sharedHandsSystem = default!;
+    [Dependency] private readonly SharedStackSystem _stack = default!;
     [Dependency] protected readonly SharedTransformSystem TransformSystem = default!;
-    [Dependency] private   readonly SharedUserInterfaceSystem _ui = default!;
+    [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
     [Dependency] protected readonly UseDelaySystem UseDelay = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
     [Dependency] protected readonly CMStorageSystem CMStorage = default!;
@@ -820,12 +820,14 @@ public abstract class SharedStorageSystem : EntitySystem
         var used = GetCumulativeItemAreas((uid, storage));
 
         var isOpen = _ui.IsUiOpen(entity.Owner, StorageComponent.StorageUiKey.Key);
+        var isEmpty = used == 0;
 
         _appearance.SetData(uid, StorageVisuals.StorageUsed, used, appearance);
         _appearance.SetData(uid, StorageVisuals.Capacity, capacity, appearance);
         _appearance.SetData(uid, StorageVisuals.Open, isOpen, appearance);
         _appearance.SetData(uid, SharedBagOpenVisuals.BagState, isOpen ? SharedBagState.Open : SharedBagState.Closed, appearance);
         _appearance.SetData(uid, StackVisuals.Hide, !isOpen, appearance);
+        _appearance.SetData(uid, SharedEmptyStorageVisuals.StorageState, isEmpty ? SharedStorageState.Empty : SharedStorageState.NotEmpty, appearance);
     }
 
     /// <summary>

--- a/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Throwable/packets.yml
+++ b/Resources/Prototypes/_CM14/Entities/Objects/Weapons/Throwable/packets.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   abstract: true
   parent: BaseStorageItem
   id: CMPacketBase
@@ -6,7 +6,11 @@
   components:
   - type: Sprite
     sprite: _CM14/Objects/Storage/packets.rsi
-    state: general_packet
+    layers:
+    - state: general_packet
+    - state: general_packet_e
+      map: [ "emptyLayer" ]
+      visible: false
   - type: Item
     size: Normal
   - type: Storage
@@ -19,6 +23,13 @@
   - type: UseDelay
     delay: 0.5
   - type: FixedItemSizeStorage
+  - type: GenericVisualizer
+    visuals:
+      enum.SharedEmptyStorageVisuals.StorageState:
+        emptyLayer:
+          Empty: { visible: true }
+          NotEmpty: { visible: false }
+  - type: Appearance
 
 - type: entity
   parent: CMPacketBase
@@ -27,7 +38,11 @@
   description: It contains three HEDP high explosive grenades.
   components:
   - type: Sprite
-    state: hedp_packet
+    layers:
+    - state: hedp_packet
+    - state: hedp_packet_e
+      map: [ "emptyLayer" ]
+      visible: false
 
 - type: entity
   parent: CMPacketGrenadeHighExplosive
@@ -47,7 +62,11 @@
   description: It contains three HEFA grenades. Don't tell the HEFA order.
   components:
   - type: Sprite
-    state: hefa_packet
+    layers:
+    - state: hefa_packet
+    - state: hefa_packet_e
+      map: [ "emptyLayer" ]
+      visible: false
 
 - type: entity
   parent: CMPacketGrenadeFrag


### PR DESCRIPTION
## About the PR
* Added a shared empty layer state for storages
* Set grenades packets prototypes to use empty layers

## Media
Recording

https://github.com/CM-14/CM-14/assets/167775671/28bf82ab-da9a-4c61-b2d7-e13fe921cef0

This is the minor fix for https://github.com/CM-14/CM-14/issues/2411

## Technical detail

This might have been done more elegantly by expanding the `BagOpenVisuals` and setting it to a `CMStorageVisuals` but this is my first C# change and wanted to make it simple.